### PR TITLE
make travis builds fails if errors found in output.

### DIFF
--- a/_layouts/project.html.haml
+++ b/_layouts/project.html.haml
@@ -166,7 +166,7 @@
             %li
               %a{:href=>"http://community.jboss.org/community/tools?view=discussions", :title => "Ask questions on the forum"} Ask questions on the forum
             %li
-              %a{:hr ef=>"irc://irc.freenode.org/jbosstools", :title => "Talk on IRC"} Talk with us on IRC
+              %a{:href=>"irc://irc.freenode.org/jbosstools", :title => "Talk on IRC"} Talk with us on IRC
         .span3.offset1
           %h4 Licenses
           %p Most plugins are available under the Eclipse Public License (EPL) others Lesser General Public License (LGPL). 


### PR DESCRIPTION
Now rakefile will check  for syntax errors in output.

This initial PR   also contains a   bug in project layout to see that the PR will cause itself to fail.

Don't apply this before we've seen travis fail the PR _And_ we fixed the layout bug AND then see travis fix it again.
