### PR TITLE
JBIDE-17096 - JBT 2.1.2.GA displayed with "Development" label instead of "Stable"

### DIFF
--- a/_ext/products_helper.rb
+++ b/_ext/products_helper.rb
@@ -33,14 +33,13 @@ module Awestruct
             return higher_product_version
           end
         end
-        puts "   Final version for #{product_id} (#{version}): #{final_version} does not exist yet."
         nil
       end
       module_function :get_higher_version
       
       # Returns a build type based on the given version 
       def get_build_type(site, product_id, product_version)
-        if is_final_version(product_version)
+        if is_stable_version(product_version)
           return :stable
         elsif is_nightly_version(product_version)
           return :nightly
@@ -62,22 +61,25 @@ module Awestruct
       end
       module_function :get_build_type_label
      
-      def get_final_version(site, product_id, product_version)
+      def get_stable_version(site, product_id, product_version)
         main_version = get_main_version(product_version)
         final_version = main_version << ".Final"
+        ga_version = main_version << ".GA"
         site.products[product_id].streams.each do |stream_id, product_versions|
-          if product_versions.include? final_version
+          if product_versions.include? final_version 
             return final_version
+          elsif product_versions.include? ga_version
+            return ga_version
           end
         end
         nil
       end
-      module_function :get_final_version
+      module_function :get_stable_version
             
-      def is_final_version(product_version)
-        product_version.end_with? ".Final"  
+      def is_stable_version(product_version)
+        (product_version.end_with? ".Final") || (product_version.end_with? ".GA")
       end
-      module_function :is_final_version
+      module_function :is_stable_version
       
       def is_nightly_version(product_version)
         product_version.end_with? ".Nightly"  
@@ -91,7 +93,7 @@ module Awestruct
             unless stream_versions[product_version].nil? then
               product_archived = false
               # final versions are not considered archived
-              product_archived = stream_versions[product_version][:archived] ||= false unless is_final_version(product_version)
+              product_archived = stream_versions[product_version][:archived] ||= false unless is_stable_version(product_version)
               #puts " #{product_id} #{product_version} active: #{!product_archived}"
               return !product_archived
             end

--- a/_ext/whatsnew.rb
+++ b/_ext/whatsnew.rb
@@ -41,10 +41,10 @@ module Awestruct
             whatsnew_page = get_whatsnew_page(site, component_page.product_id, component_page.product_version)
             add_component_page(whatsnew_page, component_page)
             # now, deal with *.Final* versions if they exist in site.products
-            unless ProductsHelper.is_final_version(component_page.component_version)
-              product_final_version = ProductsHelper.get_final_version(site, component_page.product_id, component_page.product_version)
-              unless product_final_version.nil? 
-                whatsnew_final_page = get_whatsnew_page(site, component_page.product_id, product_final_version)
+            unless ProductsHelper.is_stable_version(component_page.component_version)
+              product_stable_version = ProductsHelper.get_stable_version(site, component_page.product_id, component_page.product_version)
+              unless product_stable_version.nil? 
+                whatsnew_final_page = get_whatsnew_page(site, component_page.product_id, product_stable_version)
                 add_component_page(whatsnew_final_page, component_page)
               end
             end

--- a/_ext/whatsnew_helper.rb
+++ b/_ext/whatsnew_helper.rb
@@ -6,7 +6,7 @@ module Awestruct
       
       # returns the list of pages that will appear in the sidenavbar
       def get_active_whatsnew_pages(site, product_id, product_version) 
-        site.whatsnew_pages[product_id].values.select{|p| p.product_active == true && (is_final_version(p.product_version) || !exists_final_version_whatsnew_page(site, p.product_id, p.product_version))}
+        site.whatsnew_pages[product_id].values.select{|p| p.product_active == true && (is_stable_version(p.product_version) || !exists_stable_version_whatsnew_page(site, p.product_id, p.product_version))}
       end
       
       # Returns the list of pages whose version match the given version (minus the qualifier) 
@@ -15,7 +15,7 @@ module Awestruct
         site.whatsnew_pages[product_id].select{|version, p| (version.start_with? main_version) && (version != product_version)}
       end
       
-      def get_final_version_whatsnew_page(site, product_id, product_version)
+      def get_stable_version_whatsnew_page(site, product_id, product_version)
         main_version = get_main_version(product_version)
         final_version = main_version << ".Final"
         site.whatsnew_pages[product_id].values.select{|p| p.product_version == final_version}.first
@@ -26,16 +26,16 @@ module Awestruct
       end
       
       def get_aggregate_whatsnew_page(site, product_id, product_version)
-        if exists_final_version_whatsnew_page(site, product_id, product_version)
-          get_final_version_whatsnew_page(site, product_id, product_version)
+        if exists_stable_version_whatsnew_page(site, product_id, product_version)
+          get_stable_version_whatsnew_page(site, product_id, product_version)
         else
           aggregated_whatsnew_page = get_current_version_whatsnew_page(site, product_id, product_version)
         end
       end
       
-      def exists_final_version_whatsnew_page(site, product_id, product_version)
-        #puts " Checking if final version for #{product_id}.#{product_version} exists: #{!(get_final_version_whatsnew_page(site, product_id, product_version).nil?)}"
-        return !(get_final_version_whatsnew_page(site, product_id, product_version).nil?)
+      def exists_stable_version_whatsnew_page(site, product_id, product_version)
+        #puts " Checking if final version for #{product_id}.#{product_version} exists: #{!(get_stable_version_whatsnew_page(site, product_id, product_version).nil?)}"
+        return !(get_stable_version_whatsnew_page(site, product_id, product_version).nil?)
       end
       
     end

--- a/_layouts/whatsnew_aggregated.html.haml
+++ b/_layouts/whatsnew_aggregated.html.haml
@@ -5,7 +5,7 @@ tab: docs
 - page.title = "#{page.product_name} #{page.product_version}"
 - component_ids = page.component_news.keys.sort{|x,y| site.components[x].name <=> site.components[y].name}
 
-- if is_final_version(page.product_version)
+- if is_stable_version(page.product_version)
   -# Banner for .Final versions (it's an aggregate of non-.Final pages)
   - related_whatsnew_pages = get_related_whatsnew_pages(site, page.product_id, page.product_version)
   - unless related_whatsnew_pages.empty?
@@ -20,7 +20,7 @@ tab: docs
             %span><= ",&nbsp;" 
 - else 
   -# Banner for non-.Final version pages which are related a an existing .Final version page
-  - final_whatsnew_page = get_final_version_whatsnew_page(site, page.product_id, page.product_version)
+  - final_whatsnew_page = get_stable_version_whatsnew_page(site, page.product_id, page.product_version)
   - unless final_whatsnew_page.nil?
     .row-fluid
       .span12.alert.alert-warning><

--- a/documentation/whatsnew/server/whatsnew.rb
+++ b/documentation/whatsnew/server/whatsnew.rb
@@ -40,9 +40,9 @@ module Awestruct
             add_component_page(whatsnew_page, component_page)
             # now, deal with *.Final* versions if they exist in site.products
             unless component_page.component_version.include? ".Final"
-              product_final_version = get_final_version(site, component_page.product_id, component_page.product_version)
-              unless product_final_version.nil? 
-                whatsnew_final_page = get_whatsnew_page(site, component_page.product_id, product_final_version)
+              product_stable_version = get_stable_version(site, component_page.product_id, component_page.product_version)
+              unless product_stable_version.nil? 
+                whatsnew_final_page = get_whatsnew_page(site, component_page.product_id, product_stable_version)
                 add_component_page(whatsnew_final_page, component_page)
               end
             end


### PR DESCRIPTION
Renamed utility function, too.
