### PR TITLE
JBIDE-17122 - Website: download section improvements

### DIFF
--- a/_config/products.yml
+++ b/_config/products.yml
@@ -63,7 +63,13 @@ devstudio:
         blog_announcement_url: /blog/2014-04-14-beta1-for-luna.html
         marketplace_url: http://marketplace.eclipse.org/node/1616973
         marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=1616973
-        download_url: https://www.jboss.org/products/devstudio#earlyaccess
+        installers: 
+          - name: Universal Multi-Platform Standalone Installer
+            url: http://www.redhat.com/j/elqNow/elqRedir.htm?ref=http://www.jboss.org/download-manager/content/origin/files/sha256/25/2550fbb912f42b6c0e60d124cc0d5b7c1a26b1767e27a0ecd6f2b9c36f3b3d9a/jbdevstudio-product-universal-8.0.0.Beta1-v20140408-2350-B93.jar
+            file_size: 482MB
+          - name: Universal Multi-Platform Standalone Installer bundled with EAP 6.2.0
+            url: http://www.redhat.com/j/elqNow/elqRedir.htm?ref=https://www.jboss.org/download-manager/content/origin/files/sha256/5f/5f7a06b642bf212a89c9526b2e477bab33cc9aa6b0bb2bb63e8e23e5586b4266/jbdevstudio-product-eap-universal-8.0.0.Beta1-v20140408-2350-B93.jar
+            file_size: 609MB
         zips:
           - name: Installer With EAP 6.2.0
             file_size: 613MB
@@ -87,11 +93,17 @@ devstudio:
         #blog_announcement_url: http://bit.ly/jbt-412
         marketplace_url: http://marketplace.eclipse.org/node/827807
         marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=827807
-        download_url: https://www.jboss.org/products/devstudio
+        installers: 
+          - name: Universal Multi-Platform Standalone Installer
+            url: http://www.redhat.com/j/elqNow/elqRedir.htm?ref=http://www.jboss.org/download-manager/content/origin/files/sha256/93/9377ef0b9a50beebd1ccc26bfa8390a1f3b96a1a9f1c2dc415d107c05b1c50ad/jbdevstudio-product-universal-7.1.1.GA-v20140314-2145-B688.jar
+            file_size: 482MB
+          - name: Universal Multi-Platform Standalone Installer bundled with EAP 6.2.0
+            url: http://www.redhat.com/j/elqNow/elqRedir.htm?ref=http://www.jboss.org/download-manager/content/origin/files/sha256/8d/8d6bf16eccb2f4bd9612e18a8dcce5b488296c8725b96107b6f949f8e0481d32/jbdevstudio-product-eap-universal-7.1.1.GA-v20140314-2145-B688.jar
+            file_size: 609MB
         zips:
           - name: Update site (including sources) bundle of JBoss Developer Studio
             file_size: 713MB
-            url: https://devstudio.jboss.com/updates/7.0.0/jbdevstudio-updatesite-7.1.1.GA-v20140314-2145-B688.zip
+            url: http://www.redhat.com/j/elqNow/elqRedir.htm?ref=http://www.jboss.org/download-manager/content/origin/files/sha256/e9/e983aba26f1080bed83ce2b705885a079a56df05f20c67d4a63b32bfd265511d/jbdevstudio-product-Update-7.1.1.GA-v20140314-2145-B688.zip
             md5_url: https://devstudio.jboss.com/updates/7.0.0/jbdevstudio-updatesite-7.1.1.GA-v20140314-2145-B688.zip.MD5
       7.1.0.GA:
         release_date: 2013-12-16
@@ -104,7 +116,11 @@ devstudio:
         # comment out marketplace and point download_url at the EA page
         #marketplace_url: http://marketplace.eclipse.org/node/827807
         #marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=827807
-        download_url: https://devstudio.jboss.com/earlyaccess/7.1.0.GA.html
+        old_download_url: https://devstudio.jboss.com/earlyaccess/7.1.0.GA.html
+        installers: 
+          - name: Universal Multi-Platform Standalone Installer
+            url: https://devstudio.jboss.com/earlyaccess/builds/development/7.1.0.GA/jbdevstudio-product-universal-7.1.0.GA-v20131208-0703-B592.jar
+            file_size: 486MB
         zips:
           - name: Update site (including sources) bundle of JBoss Developer Studio
             file_size: 719MB
@@ -120,7 +136,8 @@ devstudio:
         # comment out marketplace and point download_url at the EA page
         #marketplace_url: http://marketplace.eclipse.org/node/827807
         #marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=827807
-        download_url: https://devstudio.jboss.com/earlyaccess/7.0.1.GA.html
+        #broken link: 
+        #download_url: https://devstudio.jboss.com/earlyaccess/7.0.1.GA.html
         zips:
           - name: Update site (including sources) bundle of JBoss Developer Studio
             file_size: 696MB
@@ -135,7 +152,10 @@ devstudio:
         release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/6.0/html-single/6.0.1_Release_Notes/index.html
         marketplace_url: http://marketplace.eclipse.org/node/503834
         marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=503834
-        download_url: https://devstudio.jboss.com/earlyaccess/6.0.1.GA.html
+        installers: 
+          - name: Universal Multi-Platform Standalone Installer
+            url: https://devstudio.jboss.com/earlyaccess/builds/stable/6.0.1.GA/jbdevstudio-product-universal-6.0.1.GA-v20130327-2052-B361.jar
+            file_size: 385MB
         zips:
           - name: Update site (including sources) bundle of JBoss Developer Studio
             file_size: 441MB
@@ -150,7 +170,10 @@ devstudio:
         release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/5.0/html-single/5.0.2_Release_Notes/index.html
         marketplace_url: http://marketplace.eclipse.org/node/121986
         marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=121986
-        download_url: https://devstudio.jboss.com/earlyaccess/5.0.0.GA.html
+        installers: 
+          - name: Universal Multi-Platform Standalone Installer
+            url: https://devstudio.jboss.com/earlyaccess/builds/stable/5.0.0.GA/jbdevstudio-product-universal-5.0.0.v20120615-1714-H213-GA.jar
+            file_size: 385MB
         zips:
           - name: Update site (including sources) bundle of JBoss Developer Studio
             file_size: 373MB

--- a/_ext/downloads.rb
+++ b/_ext/downloads.rb
@@ -56,6 +56,7 @@ module Awestruct
               info.required_devstudio_version = build_info["required_devstudio_version"]
               #info.supported_devstudio_is_version = build_info["supported_devstudio_is_version"]
               info.whatsnew_url = get_whatsnew_page_output_path(product_id, build_version) 
+              info.installers = build_info["installers"]
               info.update_site_url = build_info["update_site_url"]
               info.marketplace_install_url = build_info["marketplace_install_url"]
               info.zips = build_info["zips"]
@@ -66,9 +67,9 @@ module Awestruct
               
               # used to provide links to download .Final versions on /downloads
               # and links to latest builds per type on /download/<product_id>
-              if (!build_type_label.nil? &&
-                   (@site.latest_builds_download_pages[product_id][build_type_label].nil? ||
-                     (@site.latest_builds_download_pages[product_id][build_type_label].build_info.version <=> download_page.build_info.version) == -1 ))
+              if (!build_type_label.nil? && 
+                  (@site.latest_builds_download_pages[product_id][build_type_label].nil? || 
+                    (@site.latest_builds_download_pages[product_id][build_type_label].build_info.version <=> download_page.build_info.version) == -1 ))
                 @site.latest_builds_download_pages[product_id][build_type_label] = download_page
               end
             end
@@ -83,7 +84,7 @@ module Awestruct
               jbt_core_download_page = site.download_pages[:jbt_core][required_jbt_core_version]
               if (!jbt_core_download_page.nil? && (jbt_core_download_page.build_info.supported_jbt_is_version.nil? || 
                  (jbt_core_download_page.build_info.supported_jbt_is_version <=> product_version) == -1 ))
-                puts "linking jbt_is #{product_version} to jbt_core #{required_jbt_core_version}"
+                #puts "linking jbt_is #{product_version} to jbt_core #{required_jbt_core_version}"
                 jbt_core_download_page.build_info.supported_jbt_is_version = product_version
               end
             end
@@ -99,7 +100,7 @@ module Awestruct
               devstudio_download_page = site.download_pages[:devstudio][required_devstudio_version]
               if (!devstudio_download_page.nil? && (devstudio_download_page.build_info.supported_devstudio_is_version.nil? || 
                  (devstudio_download_page.build_info.supported_devstudio_is_version <=> product_version) == -1 ))
-                puts "linking devstudio_is #{product_version} to devstudio #{required_devstudio_version}"
+                #puts "linking devstudio_is #{product_version} to devstudio #{required_devstudio_version}"
                 devstudio_download_page.build_info.supported_devstudio_is_version = product_version
               end
             end

--- a/_layouts/download_single_version.html.haml
+++ b/_layouts/download_single_version.html.haml
@@ -32,7 +32,7 @@ tab: downloads
         &#124;
       -# Blog announcement
       - unless page.build_info.blog_announcement_url.nil?
-        %a{:href=>relative(page.build_info.blog_announcement_url)} Blog Announcement
+        %a{:href=>relative(page.build_info.blog_announcement_url)} Blog Announcement 
         &#124;
       -# JBoss Tools has a What's New
       - unless page.build_info.whatsnew_url.nil?
@@ -42,7 +42,7 @@ tab: downloads
       - unless page.build_info.release_notes_url.nil?
         %a{:href=>relative(page.build_info.release_notes_url)} Release Notes 
         &#124;
-      %a{:href=>relative("/downloads/installation.html")} Installation
+      %a{:href=>relative("/downloads/installation.html")} Installation Instructions
       
     - if page.build_info.build_type_label == "stable"
       .alert.alert-success
@@ -71,8 +71,6 @@ tab: downloads
         %strong 
           %a{:href=>higher_version_download_page.output_path} #{page.build_info.name} #{higher_version_download_page.build_info.version}
         is our latest stable release for #{page.build_info.eclipse_version.full_name}
-          
-    
         
     - unless page.build_info.eclipse_version.requirements.nil?
       .alert.alert-requirements
@@ -92,12 +90,16 @@ tab: downloads
           %a{:href=>relative(jbt_core_page.output_path)} #{site.products[:jbt_core].name} #{page.build_info.required_jbt_core_version}
         - elsif page.build_info.product_id.to_s == "devstudio_is"
           - devstudio_page = site.download_pages[:devstudio][page.build_info.required_devstudio_version]
-          Requirements: #{page.build_info.eclipse_version.requirements} plus
+          %strong Requirements:
+          #{page.build_info.eclipse_version.requirements} plus
           %a{:href=>relative(devstudio_page.output_path)} #{site.products[:devstudio].name} #{page.build_info.required_devstudio_version}
-        
     
     #installation_tabs.tabbable
       %ul.nav.nav-tabs
+        - unless page.build_info.installers.nil? 
+          %li{:id=>"direct_download_tab"}
+            %a{:href=>"#direct_download", :"data-toggle"=>"tab"}
+              Installer
         - unless page.build_info.marketplace_install_url.nil? 
           %li{:id=>"marketplace_tab"}
             %a{:href=>"#marketplace", :"data-toggle"=>"tab"}
@@ -115,10 +117,45 @@ tab: downloads
             %a{:href=>"#zips", :"data-toggle"=>"tab"}
               Update Site Zip
         
-        
     #installation-tabs-content.tab-content     
+      - unless page.build_info.installers.nil? 
+        .tab-pane{:id=>"direct_download"}
+          .alert
+            :markdown 
+              **Registration required**
+              Downloads require accepting the 
+              [terms and conditions](http://www.jboss.org/developer-program/termsandconditions) 
+              of the JBoss Developer Program which provides $0 subscriptions for development use only.
+          %p Select the Standalone Installer you want to download
+          %table.center
+            %tr
+              %th<Name
+              %th<Size
+              %th<Links
+            - page.build_info.installers.each do |installer|
+              %tr
+                %td #{installer.name}  
+                %td.right 
+                  - if installer.file_size?
+                    #{installer.file_size}              
+                %td 
+                  - if installer.url.end_with? "zip"
+                    %a{:href=>installer.url} zip
+                  - elsif installer.url.end_with? "jar"
+                    %a{:href=>installer.url} jar
+                  - elsif installer.url.end_with? "html"
+                    %a{:href=>installer.url} html
+                  - elsif installer.url.end_with? "tar.gz"
+                    %a{:href=>installer.url} tar.gz
+                  - else
+                    %a{:href=>installer.url} unknown
+                    - puts "Unknown file type: #{installer.url} (in installers of #{page.build_info.name} #{page.build_info.version})"
+                  - if installer.md5_url?
+                    (
+                    %a{:href=>installer.md5_url}> md5
+                    )
+      
       - unless page.build_info.marketplace_install_url.nil? 
-        -# use markdown or asciidoc instead 
         .tab-pane{:id=>"marketplace"}
           %p
             Drag and drop this


### PR DESCRIPTION
Fixed link to latest stable version of JBT and DevStudio on /downloads (older version was retained)
Set "archived: true" on DevStudio 7.1.0.GA (it does not appear on side nav menu of individual download pages)
Added a "Standalone Installer" section similar to the "update site Zips" one with links to download standalone or
standalone with EAP (when configured in products.yml)
Fixed "unknown" file type (some URLs ended with "/download", which was not an expected file extension)
Added a log message when an unknown file type is detected, for easier fixing.
