### PR TITLE
JBIDE-17047 - fill in missing downloads in product.yml - release not broken link

### DIFF
--- a/_config/products.yml
+++ b/_config/products.yml
@@ -201,7 +201,7 @@ jbt_core:
             url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Beta1_2014-04-08_19-49-44-B47.zip
             md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Beta1_2014-04-08_19-49-44-B47.zip.MD5
           - name: Release Notes
-            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/zz_Release_Notes_4.2.0.Beta1.readme.html
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/zz_Release_Notes_4.2.0.Beta1.readme.htm
       4.2.0.Alpha2:
         release_date: 2014-02-14
         build_type: development

--- a/_layouts/download_single_version.html.haml
+++ b/_layouts/download_single_version.html.haml
@@ -223,7 +223,7 @@ tab: downloads
                     %a{:href=>zip.url} zip
                   - elsif zip.url.end_with? "jar"
                     %a{:href=>zip.url} jar
-                  - elsif zip.url.end_with? "html"
+                  - elsif (zip.url.end_with?("html") || zip.url.end_with?("htm"))
                     %a{:href=>zip.url} html
                   - elsif zip.url.end_with? "tar.gz"
                     %a{:href=>zip.url} tar.gz


### PR DESCRIPTION
Fixing broken link because file extension on SourceForge is ".htm" instead of ".html"
