### PR TITLE
JBIDE-17937 - Add a 'Nightly' label on N&N when it's not release yet.

### DIFF
--- a/_config/products.yml
+++ b/_config/products.yml
@@ -356,6 +356,10 @@ jbt_core:
           - name: Release Notes
             file_size: 13kB
             url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.x/zz_Release_Notes_4.1.2.Final.readme.html
+      4.1.2.CR1:
+        archived: true
+        build_type: development
+        renamed_as: 4.1.2.Final
       4.1.1.Final:
         archived: true
         build_type: stable
@@ -498,6 +502,10 @@ jbt_core:
           - name: Release Notes 4.1.0
             file_size: 5.7kB
             url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.x/zz_Release_Notes_4.1.0.Final.readme.html
+      4.1.0.CR1:
+        archived: true
+        build_type: development
+        renamed_as: 4.1.0.Final
       4.1.x.Nightly:   
         archived: true
         build_type: nightly

--- a/_ext/downloads.rb
+++ b/_ext/downloads.rb
@@ -8,10 +8,10 @@ module Awestruct
       @@index_path = "/downloads/index.html"
       @@output_path_prefix = "/downloads/"
       @@download_single_version_layout_path = "download_single_version.html.haml"
+      @@download_renamed_version_layout_path = "download_renamed_version.html.haml"
       @@downloads_per_product_layout_path = "downloads_per_product_summary.html.haml"
       @@downloads_per_eclipse_stream_layout_path = "downloads_per_eclipse_stream_summary.html.haml"
-      #@@build_types = {:stable => [".GA", ".Final"], :development=>[".Alpha", ".Beta", ".CR"], :nightly=>["nightly", "Nightly"]}
-
+      
       def initialize()
       end
 
@@ -19,7 +19,7 @@ module Awestruct
       def execute(site)
         $LOG.debug "*** Executing downloads extension..." if $LOG.debug?
         # making these labels available in layouts, too.
-        site.labels = {:stable=>"Stable", :development=>"Development", :nightly=>"Nightly"}
+        site.labels = {:stable=>"Stable", :development=>"Development", :nightly=>"Nightly", :unreleased=>"Coming Soon"}
         @site = site
         @site.download_pages = Hash.new
         @site.latest_builds_download_pages = Hash.new
@@ -128,6 +128,7 @@ module Awestruct
             end
           end
         end
+        
         $LOG.debug "*** Done with downloads extension." if $LOG.debug?
       end
       
@@ -135,7 +136,11 @@ module Awestruct
         page_title ||= @site.products[product_id].name + " " + build_info.version.to_s
         product_path_fragment = @site.products[product_id].url_path_fragment
         path = @@output_path_prefix + product_path_fragment + "/" + eclipse_version.url_path_fragment + "/" + page_path_fragment + ".html"
-        download_page = find_layout_page(@@download_single_version_layout_path)
+        if build_info.renamed_as.nil?
+          download_page = find_layout_page(@@download_single_version_layout_path)
+        else
+          download_page = find_layout_page(@@download_renamed_version_layout_path)
+        end
         download_page.output_path = File.join(path)
         download_page.title = page_title
         download_page.build_info = build_info

--- a/_ext/whatsnew.rb
+++ b/_ext/whatsnew.rb
@@ -7,7 +7,7 @@ module Awestruct
     class Whatsnew
       
       @@whatsnew_layout_path = "whatsnew_aggregated.html.haml"
-      @@whatsnew_overview_layout_path = "whatsnew_overview.html.haml"
+      @@whatsnew_standalone_path = "whatsnew_aggregated.html.haml"
       
       def initialize(source_path_prefix, target_path_prefix)
         puts "Initializing Whatsnew"

--- a/_layouts/download_renamed_version.html.haml
+++ b/_layouts/download_renamed_version.html.haml
@@ -1,0 +1,53 @@
+---
+layout: project
+tab: downloads
+---
+.row-fluid
+  .span3.bs-docs-sidebar
+    %ul.nav.nav-list.bs-docs-sidenav
+      - active_page_found = false
+      -# show active versions
+      - site.download_pages[page.product_id].each do |product_version, download_page| 
+        - if !download_page.build_info.archived
+          - active_page_found = active_page_found || download_page.build_info.version == page.build_info.version
+          %li{:class=>("active" if download_page.build_info.version == page.build_info.version)}
+            %a{:href=>relative(download_page.output_path)}
+              %span
+                #{download_page.build_info.version}
+              - unless download_page.build_info.build_type_label.nil?
+                %span.visible-desktop.visible-phone{:class=>"label label_#{download_page.build_info.build_type_label}"}
+                  #{site.labels[download_page.build_info.build_type_label]}
+      %li
+        %a{:href=>relative("/downloads/overview.html")} All downloads
+        
+  .span9#download.well.post-bg
+    %h2.center
+      #{page.build_info.name} #{page.build_info.version}
+      - unless page.build_info.build_type.nil?
+        %span#displayed-version{:class=>"label label_#{page.build_info.build_type}"}
+          #{site.labels[page.build_info.build_type]}
+    .center
+      - unless page.build_info.documentation_url.nil?
+        %a{:href=>relative(page.build_info.documentation_url)} Documentation
+        &#124;
+      -# Blog announcement
+      - unless page.build_info.blog_announcement_url.nil?
+        %a{:href=>relative(page.build_info.blog_announcement_url)} Blog Announcement 
+        &#124;
+      -# JBoss Tools has a What's New
+      - unless page.build_info.whatsnew_url.nil?
+        %a{:href=>relative(page.build_info.whatsnew_url)} What's New 
+        &#124;
+      -# devstudio has Release Notes
+      - unless page.build_info.release_notes_url.nil?
+        %a{:href=>relative(page.build_info.release_notes_url)} Release Notes 
+        &#124;
+      %a{:href=>relative("/downloads/installation.html")} Installation Instructions
+      
+    .alert.alert-warning
+      %strong Heads up! 
+      This version was promoted as&nbsp;
+      %a{:href=>"#{page.build_info.renamed_as}.html"}>
+        %strong<> #{page.build_info.renamed_as}
+      \.
+   

--- a/_layouts/download_single_version.html.haml
+++ b/_layouts/download_single_version.html.haml
@@ -15,7 +15,7 @@ tab: downloads
               %span
                 #{download_page.build_info.version}
               - unless download_page.build_info.build_type_label.nil?
-                %span{:class=>"label label_#{download_page.build_info.build_type_label}"}
+                %span.visible-desktop.visible-phone{:class=>"label label_#{download_page.build_info.build_type_label}"}
                   #{site.labels[download_page.build_info.build_type_label]}
       %li
         %a{:href=>relative("/downloads/overview.html")} All downloads
@@ -23,9 +23,9 @@ tab: downloads
   .span9#download.well.post-bg
     %h2.center
       #{page.build_info.name} #{page.build_info.version}
-      - unless page.build_info.build_type_label.nil?
-        %span#displayed-version{:class=>"label label_#{page.build_info.build_type_label}"}
-          #{site.labels[page.build_info.build_type_label]}
+      - unless page.build_info.build_type.nil?
+        %span#displayed-version{:class=>"label label_#{page.build_info.build_type}"}
+          #{site.labels[page.build_info.build_type]}
     .center
       - unless page.build_info.documentation_url.nil?
         %a{:href=>relative(page.build_info.documentation_url)} Documentation

--- a/_layouts/whatsnew.html.haml
+++ b/_layouts/whatsnew.html.haml
@@ -17,7 +17,7 @@ tab: docs
         %a{:href=>"#"}
           #{page.product_version}
           - unless page.build_type_label.nil?
-            %span{:class=>"label label_#{current_whatsnew_page.build_type_label}"}
+            %span.visible-desktop.visible-phone{:class=>"label label_#{current_whatsnew_page.build_type_label}"}
               #{site.labels[current_whatsnew_page.build_type_label]}
         %ul.nav.nav-nested.components
           %li.component{:class=>"active"}

--- a/_layouts/whatsnew_aggregated.html.haml
+++ b/_layouts/whatsnew_aggregated.html.haml
@@ -39,7 +39,7 @@ tab: docs
             %a{:href=>relative(whatsnew_page.output_path)}
               #{whatsnew_page.product_version}
               - unless whatsnew_page.build_type_label.nil?
-                %span{:class=>"label label_#{whatsnew_page.build_type_label}"}
+                %span.visible-desktop.visible-phone{:class=>"label label_#{whatsnew_page.build_type_label}"}
                   #{site.labels[whatsnew_page.build_type_label]}
             - if whatsnew_page.product_version == page.product_version
               %ul.nav.nav-nested.components
@@ -68,6 +68,9 @@ tab: docs
     %header 
       %h1.center What's New in #{page.product_name} #{page.product_version}
       - download_page = site.download_pages[page.product_id][page.product_version]
+      - if download_page.nil? && page.build_type == :unreleased then
+        - download_page = site.latest_builds_download_pages[page.product_id][:nightly]
+      - puts "#{page.product_id} #{page.product_version}: #{page.build_type} -> #{download_page.output_path}"
       .center
         -# Blog announcement
         - unless download_page.nil? || download_page.build_info.blog_announcement_url.nil?

--- a/documentation/whatsnew/index.html.haml
+++ b/documentation/whatsnew/index.html.haml
@@ -38,25 +38,42 @@ status: yellow
           
           .item
             %p
-              %strong #{site.products[product_id].name} #{whatsnew_page.product_version}
-              is the latest 
-              %strong #{site.labels[whatsnew_page.build_type_label]}
-              version available for download.
-              
-              
               - relevant_components = whatsnew_page.component_news.keys.select{|k| k != "general"}
+              
+              - if whatsnew_page.build_type == :unreleased
+                %strong #{site.products[product_id].name} #{whatsnew_page.product_version}
+                is 
+                %strong coming soon
+                \!
+                - if relevant_components.length > 0
+                  %p See what we are preparing in it, including changes for:
+                - else
+                  %p This version is a primarily bug-fix release.
+                
+              - else 
+                %strong #{site.products[product_id].name} #{whatsnew_page.product_version}
+                is the latest 
+                %strong #{site.labels[whatsnew_page.build_type_label]}
+                version available for download.
+                - if relevant_components.length > 0
+                  %p See what's new in it, including changes for:
+                - else
+                  %p This version is a primarily bug-fix release.
+                
               - if relevant_components.length > 0
-                %p
-                  See what's new in it, including changes for:
-                %ul.columns.double
-                  - relevant_component_names = Hash.new
-                  - relevant_components.each do |component_id|
-                    - relevant_component_names[site.components[component_id].name] = component_id
-                  - relevant_component_names.sort{|x,y| x <=> y}.each do |component_name, component_id|
-                    %li 
-                      %a{:href=>relative("#{whatsnew_page.output_path}##{component_id}")} #{component_name}
-              - else
-                %p This version is a primarily bug-fix release.
+                - relevant_component_names = Hash.new
+                - relevant_components.each do |component_id|
+                  - relevant_component_names[site.components[component_id].name] = component_id
+                - relevant_component_names.keys.sort{|x,y| x <=> y}.each_index do |index|
+                  - component_name = relevant_component_names.keys[index]
+                  %a{:href=>relative("#{whatsnew_page.output_path}##{relevant_component_names[component_name]}")} #{component_name}
+                  - if index < relevant_component_names.keys.length - 3
+                    %span<>,&nbsp;
+                  - elsif index == relevant_component_names.keys.length - 2
+                    %span<> &nbsp; and &nbsp;
+                  - elsif index == relevant_component_names.keys.length - 1
+                    %span<> .
+                    
           %footer
             %a.btn.btn-small{:href=>relative(whatsnew_page.output_path)} Read more &raquo;
       

--- a/downloads/overview.html.haml
+++ b/downloads/overview.html.haml
@@ -28,9 +28,10 @@ title: All Downloads
                 - site.download_pages[product_id].each do |product_version, download_page|
                   - next if download_page.build_info.eclipse_version != eclipse_info
                   .block
-                    %a{:href=>relative(download_page.output_path)} #{product_version}
-                    - if labels[download_page.build_info.build_type_label].nil? 
-                      %span{:class=>"label label_#{download_page.build_info.build_type_label}"} #{download_page.build_info.build_type_label}
+                    %a{:href=>relative(download_page.output_path)} #{product_version} 
+                    - if (!download_page.build_info.build_type_label.nil? && labels[download_page.build_info.build_type_label].nil?) 
+                      %span{:class=>"label label_#{download_page.build_info.build_type_label}"} 
+                        #{site.labels[download_page.build_info.build_type]}
                       - labels[download_page.build_info.build_type_label] = true
                   
                   

--- a/stylesheets/jbt-styles.scss
+++ b/stylesheets/jbt-styles.scss
@@ -804,8 +804,16 @@ body {
   padding-bottom: 20px;
 
 }
+
+
+
 #download {
-  margin-top: 30px;
+  @media screen and (min-width: 980px) {
+    margin-top: 30px;
+  }
+  @media screen and (max-width: 979px) {
+    margin-top: 20px;
+  }
 }
 
 #all-downloads, #installation-tabs-content {
@@ -873,7 +881,7 @@ span.label {
   &.label_development {
     background-color: rgb(58, 135, 173);
   }
-  &.label.label_nightly {
+  &.label.label_nightly, &.label.label_unreleased {
     background-color: rgb(248, 148, 6);
   }
   &.float-right {
@@ -1109,6 +1117,12 @@ span.label {
 }
 
 .whatsnew {
+  @media screen and (min-width: 980px) {
+    margin-top: 30px;
+  }
+  @media screen and (max-width: 979px) {
+    margin-top: 20px;
+  }
   .sect1 {
     position: relative;
     padding-bottom: 2em;


### PR DESCRIPTION
mmh.. the 'Nightly' label mentionned in the JIRA label appears as a 'Coming Soon' label, but this can be changed if you don't like it..

Also, I added missing entries in products.yml for 4.1.2.CR1 and 4.1.0.CR1, which don't provide links to downloadable bits, but link to the .Final download page, instead.
