### PR TITLE
JBIDE-18484 - Show release date for all milestones, not just .Final versions

### DIFF
--- a/_layouts/download_single_version.html.haml
+++ b/_layouts/download_single_version.html.haml
@@ -48,12 +48,11 @@ bottom_javascripts: ["/javascripts/download_tabs.js"]
     - if page.build_info.build_type_label == "stable"
       .alert.alert-success
         #{page.build_info.name} #{page.build_info.version} was released on #{page.build_info.release_date}. 
-        - if page.build_info.blog_announcement_url 
-          %a{:href=>relative(page.build_info.blog_announcement_url)} Read the announcement.
-          
         
     - elsif page.build_info.build_type_label == "development"
       .alert.alert-info
+        #{page.build_info.name} #{page.build_info.version} was released on #{page.build_info.release_date}. 
+        %br
         %strong Development builds
         have received basic testing, but are not considered fully stable yet.
         
@@ -69,6 +68,7 @@ bottom_javascripts: ["/javascripts/download_tabs.js"]
       - higher_version_download_page = site.download_pages[page.build_info.product_id][higher_version]
       .alert.alert-info
         %strong Heads up! 
+        #{page.build_info.name} #{page.build_info.version} was released on #{page.build_info.release_date}, but
         %strong 
           %a{:href=>higher_version_download_page.output_path} #{page.build_info.name} #{higher_version_download_page.build_info.version}
         is our latest stable release for #{page.build_info.eclipse_version.full_name}

--- a/documentation/faq/visualeditor.adoc
+++ b/documentation/faq/visualeditor.adoc
@@ -26,7 +26,7 @@ List of supported platforms (and their IDs)for previewing/editing JSP/JSF files:
 	* Windows with Java 32-bit (win32.win32.x86)
 	* Windows with Java 64-bit (win32.win32.x86_64) - Experimental support is available in JBoss Tools 4.1.0.Beta1/JBoss Developer Studio 7.0.0.Beta1 and above.
 	** To enable it, you need to install XULRunner from this update site: http://download.jboss.org/jbosstools/updates/integration/luna/core/xulrunner/xulrunner-1.9.2_win64-2014-08-22_09-55-58-B4/
-	** If you cannot start Eclipse after this installation, you may use `–Dorg.jboss.tools.vpe.loadxulrunner=false` option as described in the next question. Please comment in  https://issues.jboss.org/browse/JBIDE-2720[JBIDE-2720] if something went wrong.
+	** If you cannot start Eclipse after this installation, you may use `-Dorg.jboss.tools.vpe.loadxulrunner=false` option as described in the next question. Please comment in  https://issues.jboss.org/browse/JBIDE-2720[JBIDE-2720] if something went wrong.
 	* Linux x86 (gtk.linux.x86) GTK2 only
 	* Linux x86-64 (gtk.linux.x86_64) GTK2 only
 	* Mac OS X Cocoa with Java 32-bit (cocoa.macosx.x86)
@@ -34,7 +34,7 @@ List of supported platforms (and their IDs)for previewing/editing JSP/JSF files:
 
 Eclipse crashes when I use Visual Editor, what can I do?::
 
-	This may happen  in JBoss Tools 3.3.0.M2 and above with Eclipse 3.7.0 due to the https://issues.jboss.org/browse/JBIDE-9144[WebKit and XULRunner conflict]. You can disable Visual Editor by adding the option `–Dorg.jboss.tools.vpe.loadxulrunner=false` to the eclipse.ini (or jbdevstudio.ini if you use JBoss Developer Studio).
+	This may happen  in JBoss Tools 3.3.0.M2 and above with Eclipse 3.7.0 due to the https://issues.jboss.org/browse/JBIDE-9144[WebKit and XULRunner conflict]. You can disable Visual Editor by adding the option `-Dorg.jboss.tools.vpe.loadxulrunner=false` to the eclipse.ini (or jbdevstudio.ini if you use JBoss Developer Studio).
 
 Visual Editor doesn't start at any platform and shows message 'The VPE editor can't be run because your system environment needs to be changed slightly'::
 	Check if you version of JBoss Developer Studio/JBoss Tools is compatible with you version of Eclipse, see the http://www.jboss.org/community/wiki/MatrixofsupportedplatformsruntimesandtechnologiesinJBossToolsJBDS[compatibility matrix].
@@ -61,4 +61,4 @@ I open HTML file on Linux and see incorrect preview image:images/ve-linux-html.p
 	That happens because xulrunner we use does not support HTML5 features. We have to use xulrunner for previewing HTML files due to the https://issues.jboss.org/browse/JBIDE-9144[WebKit and XULRunner conflict].
 	
 +
-To have correct HTML preview you should start Eclipse or JBoss Developer Studio with `–Dorg.jboss.tools.vpe.loadxulrunner=false` option in eclipse.ini or jbdevstudio.ini).
+To have correct HTML preview you should start Eclipse or JBoss Developer Studio with `-Dorg.jboss.tools.vpe.loadxulrunner=false` option in eclipse.ini or jbdevstudio.ini).


### PR DESCRIPTION
Added the release date in the alert DIVs in the download pages
Fix an invalid US-ASCII character in visualeditor.adoc (caused a failure during website build)
