### PR TITLE
Fix typo: Lunix -> Linux

### DIFF
--- a/documentation/whatsnew/jst/jst-news-4.2.0.Beta3.adoc
+++ b/documentation/whatsnew/jst/jst-news-4.2.0.Beta3.adoc
@@ -10,7 +10,7 @@
 
 Target Platform is updated with the Tern.java v.0.4.0.201407030911 in order to bring the latest improvements and fixes of JavaScript Content Assistant into JBoss Tools:
 
-* Embedded Node.js distribution provided for Windows x86/x86_64, Mac OS X, Lunix x86/x86_64
+* Embedded Node.js distribution provided for Windows x86/x86_64, Mac OS X, Linux x86/x86_64
 * Embedded Node.js is used by default, so tern works right out-of-the-box
 * ECMA5 and Browser Tern Modules are turned on by default for JavaScript projects
 * Cordova Tern Module is turned on by default for HMT projects


### PR DESCRIPTION
I guess this file is where currently published site content comes from, right?
