### PR TITLE
Fix link to download JBT download on CAT page

### DIFF
--- a/cat/index.adoc
+++ b/cat/index.adoc
@@ -23,7 +23,7 @@ To particpate please follow these steps:
 
 * Register for community membership here: http://bit.ly/jbosstoolscatsignup[registration form]
 * Subscribe to the JBoss Tools CAT mailing list here: https://lists.jboss.org/mailman/listinfo/jbosstools-cat[email subscription form]
-* Download the latest JBoss Tools bits for testing - as of today simplest to use latest staging for test: link:http://download.jboss.org/jbosstools/updates/staging/luna[Luna Staging]
+* Download the latest JBoss Tools bits for testing - currently the newest version is JBoss Tools 4.2.0.Final: link:http://download.jboss.org/jbosstools/updates/stable/luna[Luna Stable]
 * Request a JBoss JIRA account (to be used to log https://issues.jboss.org/secure/CreateIssueDetails!init.jspa?pid=10020&issuetype=1[bugs] and https://issues.jboss.org/secure/CreateIssueDetails!init.jspa?pid=10020&issuetype=2[feature requests] in JBoss Tools project): https://issues.jboss.org[JBoss JIRA]
 * And, then start testing!
 


### PR DESCRIPTION
Xavier pointed out that now that JBT 4.2 is released,
we shouldn't point to staging update site. Technically it's all
the same - the staging site points to the Final bits. But it does
not look good.
