### PR TITLE
Small update to the "using git" how-to

### DIFF
--- a/documentation/howto/using_git.adoc
+++ b/documentation/howto/using_git.adoc
@@ -171,7 +171,7 @@ image::git_terminal_button.png[The Open a Terminal Button]
 
 [[update_branch]]
 === Updating the Branch Before Implementing Changes
-When working locally on a branch, it is important to ensure the local branch is up to date before committing changes or creating a pull request (PR). As an example, if someone else has checked out the same repository and created a new branch, made changes, and merged the changes, use the following procedure to update your repository and branch before committing your own changes.
+When working locally on a branch, it is better to ensure the local branch is up to date before creating a pull request (PR). As an example, if someone else has checked out the same repository and created a new branch, made changes, and merged the changes, use the following procedure to update your repository and branch before committing your own changes.
 
 In the example below, a new branch called *TrackingID-1234* is created using the IDE. Assuming that someone else is working on the same repository and has created a new branch called *NEWBRANCH*, made changes to it, and then merged the changes back into the repository. The local branch (*TrackingID-1234*) is now out of date because it does not include the changes from *NEWBRANCH*. Use the following instructions to update the branch:
 


### PR DESCRIPTION
@mishaone after reviewing again your contribution I would like to propose the following change because:
- you can commit on your local repository even if your repo is not up-to-date with the canonical/remote repo
- if you commit on an outdated repo and then submit a PR, you may end up an extra merge commit when the remote repo owner merges your PR, or the PR may not be mergeable because of conflicts. In the first case, it can be acceptable. This is why I suggest to use the term "better". Or would "strongly recommended" be even better ? WDYT ?