### PR TITLE
JBIDE-20851 - Skip Final NN aggregation page if "include-previous: false"

### DIFF
--- a/_ext/downloads.rb
+++ b/_ext/downloads.rb
@@ -43,7 +43,7 @@ module Awestruct
             eclipse_stream.each do |build_version, build_info|
               product_info = Products_Helper.get_build_info(site, product_id, build_version, eclipse_version, build_info)
               download_page = generate_download_page(product_id, eclipse_version,
-                    build_version.to_s, product_info)
+                    build_version.to_s, product_info) unless (product_info.nil? || product_info.release_date.nil?)
 
               # used to provide links to download .Final versions on /downloads
               # and links to latest builds per type on /download/<product_id>

--- a/_ext/products_helper.rb
+++ b/_ext/products_helper.rb
@@ -30,8 +30,12 @@ module Awestruct
           # locate the stream: ie, it contains the given version
           if product_versions.include? product_version
             # sort versions by name (except nightly), retain higher one
-            higher_product_version = product_versions.keys.select{|p| get_main_version(p, false) == main_version && !is_nightly_version(p)}.sort{|p1, p2| p1 <=> p2}.last
-            #puts " higher version for #{product_id} #{product_version} is #{higher_product_version}"
+            higher_product_version = product_versions.keys.
+              select{|p| get_main_version(p, false) == main_version && !is_nightly_version(p) &&
+                !product_versions[p].nil? && !product_versions[p].release_date.nil?}.
+              sort{|p1, p2| p1 <=> p2}.last
+            puts " higher version for #{product_id} #{product_version} is #{product_versions[higher_product_version]}"
+
             return higher_product_version
           end
         end


### PR DESCRIPTION


Part 2:
- hide 4.3.0.Final from /downloads since there's no data yet
- keep the build type label ("Development") on 4.3.0.CR! since
  it is the latest release available.