### PR TITLE
DEVELOPER-1435 JBDS-3562 PR to move to the new jboss-devstudio-9.0.0.GA-CVE-2015-7501-installer-eap.jar, and update the name label on it. 

### DIFF
--- a/_config/products.yml
+++ b/_config/products.yml
@@ -90,6 +90,9 @@ devstudio:
           - name: Installer With EAP 6.4.0 CVE-2015-7501 (2015-12-08)
             url: https://www.jboss.org/download-manager/content/origin/files/sha256/1e/1efef4d2b109efd9e8136d02067a8d62e00621e5b2b1530811bf52b5aa2fca6f/jboss-devstudio-9.0.0.GA-CVE-2015-7501-installer-eap.jar
             file_size: 633MB
+          - name: Installer With EAP 6.4.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/4f/4fe77f731aa2a46a4d8568786c0c7c2d486e0926025d06a95360e9e767a2af94/jboss-devstudio-9.0.0.GA-installer-eap.jar
+            file_size: 633MB
         zips:
           - name: Update site (including sources) bundle of JBoss Developer Studio
             url: https://www.jboss.org/download-manager/content/origin/files/sha256/ff/ff2c124a3e6b2de729314745c01f990d786f326c7c8f85c15c3d9b040f5499d2/jboss-devstudio-9.0.0.GA-updatesite-core.zip

--- a/_config/products.yml
+++ b/_config/products.yml
@@ -82,7 +82,7 @@ devstudio:
         supported_devstudio_is_version: 9.0.0.Alpha2
         documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
         release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        blog_announcement_url: /blog/ga-for-mars.html
+        blog_announcement_url: /blog/ga-cve-for-mars.html
         installers:
           - name: Stand-alone Installer
             url: https://www.jboss.org/download-manager/content/origin/files/sha256/b5/b55d3b959d4922f69338095aff4d3cea639766a7c07850e539ebc0b9029e8902/jboss-devstudio-9.0.0.GA-installer-standalone.jar

--- a/_config/products.yml
+++ b/_config/products.yml
@@ -87,8 +87,8 @@ devstudio:
           - name: Stand-alone Installer
             url: https://www.jboss.org/download-manager/content/origin/files/sha256/b5/b55d3b959d4922f69338095aff4d3cea639766a7c07850e539ebc0b9029e8902/jboss-devstudio-9.0.0.GA-installer-standalone.jar
             file_size: 488MB
-          - name: Installer With EAP 6.4.0
-            url: https://www.jboss.org/download-manager/content/origin/files/sha256/4f/4fe77f731aa2a46a4d8568786c0c7c2d486e0926025d06a95360e9e767a2af94/jboss-devstudio-9.0.0.GA-installer-eap.jar
+          - name: Installer With EAP 6.4.0 CVE-2015-7501 (2015-12-08)
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/1e/1efef4d2b109efd9e8136d02067a8d62e00621e5b2b1530811bf52b5aa2fca6f/jboss-devstudio-9.0.0.GA-CVE-2015-7501-installer-eap.jar
             file_size: 633MB
         zips:
           - name: Update site (including sources) bundle of JBoss Developer Studio

--- a/_data/team/nickboldt.adoc
+++ b/_data/team/nickboldt.adoc
@@ -1,0 +1,4 @@
+= Nick Boldt
+:page-photo_64px: https://developer.jboss.org/people/nickboldt/avatar/64.png
+:page-photo_32px: https://developer.jboss.org/people/nickboldt/avatar/32.png
+:page-developer_page: https://developer.jboss.org/people/nickboldt

--- a/blog/ga-cve-for-mars.adoc
+++ b/blog/ga-cve-for-mars.adoc
@@ -1,0 +1,35 @@
+= Red Hat Developer Studio for Eclipse Mars - CVE-2015-7501 patch fix for Red Hat JBoss Enterprise Application Platform
+:page-layout: blog
+:page-author: nickboldt
+:page-tags: [release, devstudio, jbosstools, patch, eap, jbosseap, jbeap]
+:page-date: 2015-12-09
+
+An update to link:/downloads/devstudio/mars/9.0.0.GA.html[Red Hat JBoss Developer Studio 9] for Eclipse Mars are now generally available!
+
+image::/blog/images/jbds9.png[]
+
+== What's new? 
+
+This release is simply a rebuild of the https://www.jboss.org/download-manager/content/origin/files/sha256/1e/1efef4d2b109efd9e8136d02067a8d62e00621e5b2b1530811bf52b5aa2fca6f/jboss-devstudio-9.0.0.GA-CVE-2015-7501-installer-eap.jar[JBoss Developer Studio 9.0.0.GA installer that bundles JBoss EAP 6.4.0], due to https://access.redhat.com/security/cve/CVE-2015-7501[CVE-2015-7501]. The rebuild includes a patched version of https://www.jboss.org/download-manager/file/jboss-eap-6.4.0.GA.zip[EAP 6.4.0.GA].
+
+You can still download the old version if you'd like, but the patched version fixes a https://access.redhat.com/security/cve/CVE-2015-7501[security convern with apache common collections].
+
+The standalone installer is unaffected and therefore required no change. Similarly, JBoss Tools users are also unaffected unless you manually downloaded and installed EAP 6.4.0. A patched version of the https://www.jboss.org/download-manager/file/jboss-eap-6.4.0.GA.zip[EAP 6.4.0.GA is available].
+
+
+== Previous announcements
+
+For what's new in this release of JBoss Tools 4.3.0.Final or JBoss Developer Studio 9.0.0.GA, see our link:ga-for-mars.html[previous GA blog announcement].
+
+
+== What's next?
+
+We are already working on the next maintenance release for Eclipse Mars - JBoss Tools 4.3.1.Beta1 and Red Hat JBoss Developer Studio 9.1.0.Beta1 will be available shortly. 
+
+We are also working on our first Eclipse Neon based builds. Try them out here:
+
+* http://download.jboss.org/jbosstools/neon/snapshots/updates/[JBoss Tools 4.4.0.Alpha1] and https://devstudio.redhat.com/10.0/snapshots/updates/[JBoss Developer Studio 10.0.0.Alpha1]
+
+Enjoy!
+
+Nick Boldt


### PR DESCRIPTION
DO NOT APPLY until the jar's in GG / CSP. Also... do we want a separate release entry, or just a change to the existing 9.0.0.GA entry? Should we update the release date from Oct 2 to Dec 8?