### PR TITLE
JBTIS-4.3.1.Final

### DIFF
--- a/_config/products.yml
+++ b/_config/products.yml
@@ -556,7 +556,7 @@ devstudio_is:
         documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0
         release_notes_url: https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/9.0.0_Release_Notes/index.html
         release_date: 2016-05-06
-        required_devstudio_version: 9.1.0.Final
+        required_devstudio_version: 9.1.0.GA
         update_site_url: https://devstudio.redhat.com/9.0/stable/updates/integration-stack/
         blog_announcement_url: /blog/integration-stack-4.3.0.Final.html
         zips:

--- a/_config/products.yml
+++ b/_config/products.yml
@@ -79,8 +79,7 @@ devstudio:
         marketplace_url: https://marketplace.eclipse.org/node/1616973
         marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=1616973
         release_date: 2016-04-19
-        # TODO change this to 9.1.0.GA when they release their bits
-        supported_devstudio_is_version: 9.0.0.Beta1
+        supported_devstudio_is_version: 9.0.0.GA
         documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
         release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
         blog_announcement_url: /blog/ga-for-mars2.html
@@ -553,10 +552,26 @@ devstudio_is:
   url_path_fragment: devstudio_is
   streams:
     mars:
+      9.0.0.GA:
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0
+        release_notes_url: https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/9.0.0_Release_Notes/index.html
+        release_date: 2016-05-06
+        required_devstudio_version: 9.1.0.Final
+        update_site_url: https://devstudio.redhat.com/9.0/stable/updates/integration-stack/
+        blog_announcement_url: /blog/integration-stack-4.3.0.Final.html
+        zips:
+          - name: Update site bundle of JBoss Developer Studio Integration Stack
+            file_size: 144MB
+            url: https://devstudio.redhat.com/9.0/stable/updates/integration-stack/devstudio-integration-stack-9.0.0.GA.zip
+            md5_url: https://devstudio.redhat.com/9.0/stable/updates/integration-stack/devstudio-integration-stack-9.0.0.GA.zip.MD5
+          - name: Update site bundle of JBoss Developer Studio Integration Stack (Early Access)
+            file_size: 288MB
+            url: https://devstudio.redhat.com/9.0/stable/updates/integration-stack/devstudio-integration-stack-9.0.0.GA-earlyaccess.zip
+            md5_url: https://devstudio.redhat.com/9.0/stable/updates/integration-stack/devstudio-integration-stack-9.0.0.GA-earlyaccess.zip.MD5
       9.0.0.Beta1:
         documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0
         release_notes_url: https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0-Beta1/html/9.0.0_Beta1_Release_Notes/index.html
-        release_date: 2015-03-11
+        release_date: 2016-03-11
         required_devstudio_version: 9.1.0.Beta2
         update_site_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/earlyaccess
         blog_announcement_url: /blog/integration-stack-4.3.0.Beta1-for-mars.html
@@ -770,8 +785,7 @@ jbt_core:
         marketplace_url: https://marketplace.eclipse.org/node/1617241
         marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=1617241
         release_date: 2016-04-19
-        # TODO change this to 4.3.0.Final when they release their bits
-        supported_jbt_is_version: 4.3.0.Beta1
+        supported_jbt_is_version: 4.3.0.Final
         blog_announcement_url: /blog/ga-for-mars2.html
         documentation_url: http://docs.jboss.org/tools/
         zips:
@@ -1644,6 +1658,20 @@ jbt_is:
   url_path_fragment: jbosstools_is
   streams:
     mars:
+      4.3.0.Final:
+        release_date: 2016-05-06
+        required_jbt_core_version: 4.3.1.Final
+        update_site_url: http://download.jboss.org/jbosstools/mars/stable/updates/integration-stack/
+        blog_announcement_url: /blog/integration-stack-4.3.0.Final.html
+        zips:
+          - name: Update site bundle of JBoss Tools Integration Stack
+            file_size: 51MB
+            url: http://download.jboss.org/jbosstools/mars/stable/updates/integration-stack/jbosstools-integration-stack-4.3.0.Final.zip
+            md5_url: http://download.jboss.org/jbosstools/mars/stable/updates/integration-stack/jbosstools-integration-stack-4.3.0.Final.zip.MD5
+          - name: Update site bundle of JBoss Tools Integration Stack (Early Access)
+            file_size: 153MB
+            url: http://download.jboss.org/jbosstools/mars/stable/updates/integration-stack/jbosstools-integration-stack-4.3.0.Final-earlyaccess.zip
+            md5_url: http://download.jboss.org/jbosstools/mars/stable/updates/integration-stack/jbosstools-integration-stack-4.3.0.Final-earlyaccess.zip.MD5
       4.3.0.Beta1:
         release_date: 2016-03-10
         required_jbt_core_version: 4.3.1.Beta2

--- a/blog/integration-stack-4.3.0.Final.adoc
+++ b/blog/integration-stack-4.3.0.Final.adoc
@@ -1,0 +1,113 @@
+= BRMS tooling released for JBDS 9 and Eclipse Mars
+:page-layout: blog
+:page-author: pleacu
+:page-date: 2016-05-06
+:page-tags: [release, jbosstools, devstudio, jbosscentral]
+
+*Try our complete Mars.2 capable, JBDS 9.1.0 compatible Integration tooling.*
+
+.*JBoss Tools Integration Stack*
+image::/blog/images/jbosstools-jbdevstudio-blog-header.png[caption=""]
+
+CAUTION: Since JBoss Tools 4.3.0 we require Java 8 for the installation and use of all JBoss Tools, including the Integration Stack tooling.  We still support developing and running applications using older Java runtimes. See more in link:2015-06-23-beta1-for-mars.html#java-8-to-run-eclipse-older-runtimes-ok-for-builds-deployment[Beta1 blog].
+
+*JBoss Tools Integration Stack 4.3.0.Final / JBoss Developer Studio Integration Stack 9.0.0.GA*
+
+== What's an Integration Stack?
+
+The Integration Stack for JBoss Developer Studio is a set of features and plugins for Eclipse that further enhances the IDE development functionality provided by JBoss Developer Studio in support of the following frameworks:
+
+=== JBoss Fuse Development
+
+* link:/features/apachecamel.html[Fuse Tooling] - JBoss Fuse Development provides tooling for Red Hat JBoss Fuse, specifically for integrating and developing software components that work with Apache ServiceMix, ActiveMQ and Camel.  It features the latest versions of the Fuse Data Transformation tooling, SwitchYard and access to the Fuse SAP Tool Suite.
+* link:/features/switchyard.html[SwitchYard] - A lightweight service delivery framework providing full lifecycle support for developing, deploying, and managing service-oriented applications.
+
+=== JBoss Business Process and Rules Development
+
+JBoss Business Process and Rules Development plug-ins provide design, debug and testing tooling for developing business processes for Red Hat JBoss BRMS and Red Hat JBoss BPM Suite.
+
+* link:/features/bpel.html[BPEL Designer] - Orchestrating your business processes.
+* link:/features/bpmn2.html[BPMN2 Modeler] - A graphical modeling tool which allows creation and editing of Business Process Modeling Notation diagrams using graphiti.
+* link:/features/drools.html[Drools] - A Business Logic integration Platform which provides a unified and integrated platform for Rules, Workflow and Event Processing including KIE.
+* link:/features/jbpm.html[jBPM6] - A flexible Business Process Management (BPM) suite.
+
+=== JBoss Data Virtualization Development
+
+JBoss Data Virtualization Development plug-ins provide a graphical interface to manage various aspects of Red Hat JBoss Data Virtualization instances, including the ability to design virtual databases and interact with associated governance repositories.
+
+* link:/features/modeshape.html[Modeshape] - A distributed, hierarchical, transactional and consistent data store with support for queries, full-text search, events, versioning, references, and flexible and dynamic schemas. It is very fast, highly available, extremely scalable, and it is 100% open source.
+* link:/features/teiiddesigner.html[Teiid Designer] - A visual tool that enables rapid, model-driven definition, integration, management and testing of data services without programming using the Teiid runtime framework.
+
+=== JBoss Integration and SOA Development
+
+JBoss Integration and SOA Development plug-ins provide tooling for developing, configuring and deploying BRMS, SwitchYard and Fuse applications to Red Hat JBoss Fuse Service Works, Red Hat JBoss Fuse and Fuse Fabric containers, Apache ServiceMix, and Apache Karaf instances.
+
+* All of the Business Process and Rules Development plugins, plus...
+* link:/features/apachecamel.html[Fuse Apache Camel Tooling] - A graphical tool for integrating software components that works with Apache ServiceMix, Apache ActiveMQ, Apache Camel and the FuseSource distributions.
+* link:/features/switchyard.html[SwitchYard] - A lightweight service delivery framework providing full lifecycle support for developing, deploying, and managing service-oriented applications.
+
+=== SOA 5.x Development
+
+*Please note that the plugins in this category have been deprecated.
+
+* link:http://www.jboss.org/jbossesb[JBoss ESB] - An enterprise service bus for connecting enterprise applications and services.
+* link:http://docs.jboss.com/jbpm/v3.2/userguide/html_single/[jBPM3] - A flexible Business Process Management (BPM) Suite - JBoss Enterprise SOA Platform 5.3.x compatible version.
+
+NOTE: All of these components have been verified to work with the same dependencies as JBoss Tools 4.3 and Developer Studio 9.
+
+== What's Been Updated for this release?
+
+*This is the first Mars-based release so almost everything!  Specifically Business Process tooling is now released.  In addition, Early Access updates have been made to the Fuse Tooling and Data Virtualization product groups.*  See the link:https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/9.0.0_Release_Notes/index.html[Integration Stack 9.0.0.GA Release Notes] for more details.
+
+=== Released Tooling Highlights
+
+==== JBoss Business Process and Rules Development
+
+===== BPMN2 Modeler Highlights
+
+* link:https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/9.0.0_Release_Notes/sect-Resolved_Issues.html#BPMN2_Modeler_1.2.4.Final[BPMN2 Modeler 1.2.4.Final]
+
+===== Drools/jBPM6 Highlights
+
+* Note that the *Kie Navigator* is part of the Drools component.
+
+* link:https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/9.0.0_Release_Notes/sect-Resolved_Issues.html#Drools_6.4.1.Final[Drools 6.4.1 Release Notes]
+
+==== SOA 5.x Development
+
+JBoss ESB, jBPM3 and guvnor.  *These tools have been deprecated.*
+
+=== Early Access Tooling Highlights
+
+==== JBoss Fuse Development Highlights
+
+===== Fuse Tooling Highlights
+
+* Including Data Transformation, SAP and SwitchYard
+* Notice the revamped Camel route editor!
+
+See the link:https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/9.0.0_Release_Notes/sect-Resolved_Issues.html#Fuse_8.0.0.Beta2[Fuse Tooling 8.0.0.Beta2 Release Notes]
+
+===== SwitchYard Highlights
+
+* link:https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/9.0.0_Release_Notes/sect-Resolved_Issues.html#SwitchYard_2.1.0.Beta3[SwitchYard 2.1.0.Beta3 Release Notes]
+
+==== Data Virtualization Highlights
+
+===== Teiid Designer Highlights
+
+See the link:https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/9.0.0_Release_Notes/sect-Resolved_Issues.html#Teiid_Designer_10.0.0.Beta3[Teiid Designer 10.0.0.Beta3 Release Notes]
+
+=== The JBoss Tools website features tab
+
+Don't miss the link:/features[Features tab] for up to date information on your favorite Integration Stack components.
+
+== Installation
+
+The easiest way to install the Integration Stack components is to first install link:/downloads/jbosstools/mars/4.3.1.Final.html[JBoss Tools 4.3.1] or link:/downloads/devstudio/mars/9.1.0.GA.html[JBoss Developer Studio 9.1.0] and then select the Software/Update tab in the JBoss Central view.  Select the 'Enable Early Access' checkbox.
+
+For a complete set of Integration Stack installation instructions, see link:https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0/html/Install_Red_Hat_JBoss_Developer_Studio_Integration_Stack/index.html[Integration Stack Installation Instructions]
+
+_Try it out!_
+
+Paul Leacu.


### PR DESCRIPTION
@xcoulon - could you please review?  I'm having an issue with the 9.0.0.GA devstudio_is entry.  It appears correct to me.  The error is:

Regenerate /home/pleacu/git-clone/jbosstools-website/_layouts/download_single_version.html.haml
An error during rendering /home/pleacu/git-clone/jbosstools-website/home/pleacu/git-clone/jbosstools-website/_layouts/download_single_version.html.haml occurred.
Please see /home/pleacu/git-clone/jbosstools-website/downloads/devstudio_is/mars/9.0.0.GA.html for more information
localhost.localdomain - - [06/May/2016:11:29:11 EDT] "GET /downloads/devstudio_is/mars/9.0.0.GA.html HTTP/1.1" 200 0
http://localhost:4242/downloads/overview.html -> /downloads/devstudio_is/mars/9.0.0.GA.html
[2016-05-06 11:29:11] ERROR SystemExit: exit
	/home/pleacu/.rvm/gems/ruby-2.2.1@jbosstools-website/bundler/gems/awestruct-b8ad2ea56a38/lib/awestruct/engine.rb:388:in `exit'
	/home/pleacu/.rvm/gems/ruby-2.2.1@jbosstools-website/bundler/gems/awestruct-b8ad2ea56a38/lib/awestruct/engine.rb:388:in `generate_page'
	/home/pleacu/.rvm/gems/ruby-2.2.1@jbosstools-website/bundler/gems/awestruct-b8ad2ea56a38/lib/awestruct/rack/generate.rb:37:in `call'
	/home/pleacu/.rvm/gems/ruby-2.2.1@jbosstools-website/gems/rack-1.6.0/lib/rack/builder.rb:153:in `call'
	/home/pleacu/.rvm/gems/ruby-2.2.1@jbosstools-website/gems/rack-1.6.0/lib/rack/handler/webrick.rb:89:in `service'
	/home/pleacu/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:138:in `service'
	/home/pleacu/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/httpserver.rb:94:in `run'
	/home/pleacu/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/webrick/server.rb:294:in `block in start_thread'
