### PR TITLE
Add text to suspend the JBT CAT program. Refer users to AERI instead.

### DIFF
--- a/cat/index.adoc
+++ b/cat/index.adoc
@@ -4,7 +4,16 @@
 
 image::/images/jbosstools-cat-logo.png[JBoss Tools CAT Logo]
 
-Welcome to JBoss Tools Community Acceptance Testing (JBoss Tools CAT)!
+*Notice - As of August 1, 2016, the JBoss Tools Community Acceptance Testing (JBoss Tools CAT) will suspend
+operations. Many thanks to everyone who participated!*
+
+In place of the JBoss Tools CAT, we'd like to ask everyone who would
+like to contribute issues to JBoss Tools to enable the Eclipse Automated
+Reporting Interface (AERI) in JBoss Tools. You can read about configuring error reporting in JBoss Tools link:/usage/#error-reporting[here].
+
+'''
+
+Original JBoss Tools Community Acceptance Testing (JBoss Tools CAT) Documentation follows:
 
 JBoss Tools CAT is an effort to obtain feedback from the JBoss
 Tools and JBoss Developer Studio users that the features in early
@@ -19,7 +28,7 @@ important.
 
 == Get started
 
-To particpate please follow these steps:
+To participate please follow these steps:
 
 * Register for community membership here: http://bit.ly/jbosstoolscatsignup[registration form]
 * Subscribe to the JBoss Tools CAT mailing list here: https://lists.jboss.org/mailman/listinfo/jbosstools-cat[email subscription form]

--- a/getinvolved/index.html.haml
+++ b/getinvolved/index.html.haml
@@ -59,18 +59,18 @@ tab: getinvolved
         %a{:href => "https://github.com/jbosstools/jbosstools-devdoc", :target => "_NEW"} Developer wiki
   .row-fluid
     .span6
-      %h2 Community Acceptance Testing
-      We love to get community involved in testing and improving JBoss Tools. If this is something you would like to help with see
-      %a{:href=>"../cat"}JBoss Tools Community Acceptance Testing
-    
-    .span6
       %h2 Want to talk to us?
+      %p      
       The JBoss Tools community is on-line,
       %a{:href => "https://maps.google.com/maps/ms?msid=207414222803974522202.00049abcea09d1313e2f7&msa=0", :target => "_NEW" }geographically distributed
       , and communicate in a number of ways.
       Visit our
       %a{:href=>"/community"}community page
       for more information.      
+    .span6
+      %h2 Community Reported Issues
+      We'd like to ask everyone who would like to contribute issues to JBoss Tools to enable the Eclipse Automated Reporting Interface (AERI) in JBoss Tools. You can read about configuring error reporting in JBoss Tools here
+      %a{:href => "/usage/#error-reporting", :target => "_NEW" }here
 
   .row-fluid
     .span6

--- a/index.html.haml
+++ b/index.html.haml
@@ -48,11 +48,10 @@ status: green
         %section#call_for_participation
           %header
             %h2
-              %a{:href=>"/features"} Call for Participation
-          .content.center
-            %a{:href=>"/cat"}
-              %img{:src=>"/images/jbosstools-cat-logo.png", :width=>600, :height=>200}
-      
+              %a{:href => relative("/getinvolved")} Call for Participation
+            %p
+            You can contribute issues to JBoss Tools by simply
+            %a{:href => ("/usage/#error-reporting")} enabling the Eclipse Automated Reporting Interface (AERI)
     -# aside column
     %aside.span4
       .row-fluid


### PR DESCRIPTION
Intentionally leaving the cat image file and directory in case we want to re-start the cat in the future. If we can find the resources to support it, it would be a useful program. 