### PR TITLE
Trigger N&N aggregation for 4.4.1.Final even though it's not released yet

### DIFF
--- a/_config/products.yml
+++ b/_config/products.yml
@@ -838,6 +838,8 @@ jbt_core:
             url: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jboss.tools.browsersim&a=org.jboss.tools.browsersim-standalone&v=3.8.0-SNAPSHOT&e=zip
             #url: http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-browsersim-standalone_master/latest/jbosstools-4.4.0.Alpha1-browsersim-standalone.zip
             #md5_url: http://download.jboss.org/jbosstools/neon/snapshots/builds/jbosstools-browsersim-standalone_master/latest/jbosstools-4.4.0.Alpha1-browsersim-standalone.zip.sha256
+      4.4.1.Final:
+        release_date:
       4.4.1.AM3:
         update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/
         #marketplace_url: https://marketplace.eclipse.org/node/1617241


### PR DESCRIPTION
Adding an entry for 4.4.1.Final in `_config/products.yml` with an empty
`released_date` attribute.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>