### PR TITLE
JBIDE-23779 - Archive old JBoss Tools versions on Downloads and What'…

### DIFF
--- a/_config/products.yml
+++ b/_config/products.yml
@@ -189,60 +189,60 @@ devstudio:
             url: http://www.jboss.org/download-manager/content/origin/files/sha256/8e/8e8335f5c6149f0faa7dd96abc9c71dd79176bee70514abdb4f248f33a614ac2/jboss-devstudio-9.1.0.GA-src.zip
             file_size: 225MB
       9.1.0.Beta2:
-        # update_site_url: https://devstudio.redhat.com/9.0/development/updates/
-        # release_date: 2016-02-02
-        # supported_devstudio_is_version: 9.0.0.Beta1
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # blog_announcement_url: /blog/beta2-for-mars2.html
-        # archived: true
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: http://www.jboss.org/download-manager/content/origin/files/sha256/d0/d0514fe0fe3fb492d8728b8f0c48f943596ef357dc12d7ac751a98bf8dc92dc9/jboss-devstudio-9.1.0.Beta2-installer-standalone.jar
-        #     file_size: 505MB
-        #   - name: Installer With EAP 6.4.0 CVE-2015-7501
-        #     url: http://www.jboss.org/download-manager/content/origin/files/sha256/71/71d514a9206f18ac2b4b9f10491c18c80efa27f3e24ecb05b55cbf75a536efc4/jboss-devstudio-9.1.0.Beta2-installer-eap.jar
-        #     file_size: 651MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     url: http://www.jboss.org/download-manager/content/origin/files/sha256/0e/0ed7ae6e78f7c0a7a607b9dffa41eaecd56671cf8fcaf7f1712304d2c4ca7a70/jboss-devstudio-9.1.0.Beta2-updatesite-core.zip
-        #     file_size: 528MB
-        #   - name: Target Platform for JBoss Developer Studio
-        #     url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.1.0.Beta2-target-platform.zip
-        #     file_size: 471MB
-        #   - name: JBoss Central Zip
-        #     url: http://www.jboss.org/download-manager/content/origin/files/sha256/ac/ac7c578d8c1824dfacef083a0b6f4fefae14f08caac0b83b92aa91924a8cdc2b/jboss-devstudio-9.1.0.Beta2-updatesite-central.zip
-        #     file_size: 154MB
-        #   - name: Sources Zip
-        #     url: http://www.jboss.org/download-manager/content/origin/files/sha256/16/162775ca1223880bcdf3756b1167faef7caf00a3287d11e9a3ed78160de20408/jboss-devstudio-9.1.0.Beta2-src.zip
-        #     file_size: 225MB
+        update_site_url: https://devstudio.redhat.com/9.0/development/updates/
+        release_date: 2016-02-02
+        supported_devstudio_is_version: 9.0.0.Beta1
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        blog_announcement_url: /blog/beta2-for-mars2.html
+        archived: true
+        installers:
+          - name: Stand-alone Installer
+            url: http://www.jboss.org/download-manager/content/origin/files/sha256/d0/d0514fe0fe3fb492d8728b8f0c48f943596ef357dc12d7ac751a98bf8dc92dc9/jboss-devstudio-9.1.0.Beta2-installer-standalone.jar
+            file_size: 505MB
+          - name: Installer With EAP 6.4.0 CVE-2015-7501
+            url: http://www.jboss.org/download-manager/content/origin/files/sha256/71/71d514a9206f18ac2b4b9f10491c18c80efa27f3e24ecb05b55cbf75a536efc4/jboss-devstudio-9.1.0.Beta2-installer-eap.jar
+            file_size: 651MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            url: http://www.jboss.org/download-manager/content/origin/files/sha256/0e/0ed7ae6e78f7c0a7a607b9dffa41eaecd56671cf8fcaf7f1712304d2c4ca7a70/jboss-devstudio-9.1.0.Beta2-updatesite-core.zip
+            file_size: 528MB
+          - name: Target Platform for JBoss Developer Studio
+            url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.1.0.Beta2-target-platform.zip
+            file_size: 471MB
+          - name: JBoss Central Zip
+            url: http://www.jboss.org/download-manager/content/origin/files/sha256/ac/ac7c578d8c1824dfacef083a0b6f4fefae14f08caac0b83b92aa91924a8cdc2b/jboss-devstudio-9.1.0.Beta2-updatesite-central.zip
+            file_size: 154MB
+          - name: Sources Zip
+            url: http://www.jboss.org/download-manager/content/origin/files/sha256/16/162775ca1223880bcdf3756b1167faef7caf00a3287d11e9a3ed78160de20408/jboss-devstudio-9.1.0.Beta2-src.zip
+            file_size: 225MB
       9.1.0.Beta1:
-        # release_date: 2015-12-21
-        # supported_devstudio_is_version: 9.0.0.Alpha2
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # blog_announcement_url: /blog/beta1-for-mars2.html
-        # archived: true
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/e1/e14e6cb8ef0a2d2ddade71bd365c6c566480c40b2ecc9c8c02230752d626c9c9/jboss-devstudio-9.1.0.Beta1-installer-standalone.jar
-        #     file_size: 501MB
-        #   - name: Installer With EAP 6.4.0 CVE-2015-7501
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/cc/cc2d921a34d22ae99ebb428325a278b8350f58f664ad556754708e282eb650f8/jboss-devstudio-9.1.0.Beta1-installer-eap.jar
-        #     file_size: 646MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/6e/6e290569e3b5cc2d0c2f08a42de267233509143cdadc6edb5da669691cd4329d/jboss-devstudio-9.1.0.Beta1-updatesite-core.zip
-        #     file_size: 523MB
-        #   - name: Target Platform for JBoss Developer Studio
-        #     url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.1.0.Beta1-target-platform.zip
-        #     file_size: 470MB
-        #   - name: JBoss Central Zip
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/f8/f8f576f79aec0fe6a2eb99ad5303d4a5cd7a92738029f44dbe1b399eb8385b46/jboss-devstudio-9.1.0.Beta1-updatesite-central.zip
-        #     file_size: 154MB
-        #   - name: Sources Zip
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/b5/b5a55868f18971bfc6c1fb5d4415abc66acefb849cca52d5dc8ea627e092c1d5/jboss-devstudio-9.1.0.Beta1-src.zip
-        #     file_size: 224MB
+        release_date: 2015-12-21
+        supported_devstudio_is_version: 9.0.0.Alpha2
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        blog_announcement_url: /blog/beta1-for-mars2.html
+        archived: true
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/e1/e14e6cb8ef0a2d2ddade71bd365c6c566480c40b2ecc9c8c02230752d626c9c9/jboss-devstudio-9.1.0.Beta1-installer-standalone.jar
+            file_size: 501MB
+          - name: Installer With EAP 6.4.0 CVE-2015-7501
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/cc/cc2d921a34d22ae99ebb428325a278b8350f58f664ad556754708e282eb650f8/jboss-devstudio-9.1.0.Beta1-installer-eap.jar
+            file_size: 646MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/6e/6e290569e3b5cc2d0c2f08a42de267233509143cdadc6edb5da669691cd4329d/jboss-devstudio-9.1.0.Beta1-updatesite-core.zip
+            file_size: 523MB
+          - name: Target Platform for JBoss Developer Studio
+            url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.1.0.Beta1-target-platform.zip
+            file_size: 470MB
+          - name: JBoss Central Zip
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/f8/f8f576f79aec0fe6a2eb99ad5303d4a5cd7a92738029f44dbe1b399eb8385b46/jboss-devstudio-9.1.0.Beta1-updatesite-central.zip
+            file_size: 154MB
+          - name: Sources Zip
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/b5/b5a55868f18971bfc6c1fb5d4415abc66acefb849cca52d5dc8ea627e092c1d5/jboss-devstudio-9.1.0.Beta1-src.zip
+            file_size: 224MB
       9.0.0.GA:
         archived: true
         release_date: 2015-10-06
@@ -274,77 +274,77 @@ devstudio:
             url: https://www.jboss.org/download-manager/content/origin/files/sha256/94/9420cd890bdf0d5211b2a14208f601a039e43edd324e3254a8d25abdd6b24fd5/jboss-devstudio-9.0.0.GA-src.zip
             file_size: 222MB
       9.0.0.CR1:
-        # release_date: 2015-09-23
-        # archived: true
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # blog_announcement_url: /blog/cr1-for-mars.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/a1/a114f54eacba4c18c2776963d8f30782ac391f2ee7e35ebf1389d52ba1d7d0fd/jboss-devstudio-9.0.0.CR1-installer-standalone.jar
-        #     file_size: 490MB
-        #   - name: Installer With EAP 6.4.0
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/56/5692ebc72c60bd49e7c25262bedd3fc3c7579516a52e42d86765ac635d53de89/jboss-devstudio-9.0.0.CR1-installer-eap.jar
-        #     file_size: 635MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/60/60aa02300082284a3fa3c8978d6f7a050fce8b736a7bff038af1ca45ee5db53a/jboss-devstudio-9.0.0.CR1-updatesite-core.zip
-        #     file_size: 515MB
-        #   - name: Target Platform for JBoss Developer Studio
-        #     url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.0.0.CR1-target-platform.zip
-        #     file_size: 462MB
-        #   - name: JBoss Central Zip
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/90/90442d1753da7b220011ec99badf5e2551d126d1b2b74bbcf2f0d2c5c41baabb/jboss-devstudio-9.0.0.CR1-updatesite-central.zip
-        #     file_size: 155MB
-        #   - name: Sources Zip
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/f4/f49eb288824a1f972aeaf020f909d8b3854b6819bcb20a220c662258a828436a/jboss-devstudio-9.0.0.CR1-src.zip
-        #     file_size: 223MB
+        release_date: 2015-09-23
+        archived: true
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        blog_announcement_url: /blog/cr1-for-mars.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/a1/a114f54eacba4c18c2776963d8f30782ac391f2ee7e35ebf1389d52ba1d7d0fd/jboss-devstudio-9.0.0.CR1-installer-standalone.jar
+            file_size: 490MB
+          - name: Installer With EAP 6.4.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/56/5692ebc72c60bd49e7c25262bedd3fc3c7579516a52e42d86765ac635d53de89/jboss-devstudio-9.0.0.CR1-installer-eap.jar
+            file_size: 635MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/60/60aa02300082284a3fa3c8978d6f7a050fce8b736a7bff038af1ca45ee5db53a/jboss-devstudio-9.0.0.CR1-updatesite-core.zip
+            file_size: 515MB
+          - name: Target Platform for JBoss Developer Studio
+            url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.0.0.CR1-target-platform.zip
+            file_size: 462MB
+          - name: JBoss Central Zip
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/90/90442d1753da7b220011ec99badf5e2551d126d1b2b74bbcf2f0d2c5c41baabb/jboss-devstudio-9.0.0.CR1-updatesite-central.zip
+            file_size: 155MB
+          - name: Sources Zip
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/f4/f49eb288824a1f972aeaf020f909d8b3854b6819bcb20a220c662258a828436a/jboss-devstudio-9.0.0.CR1-src.zip
+            file_size: 223MB
       9.0.0.Beta2:
-        # release_date: 2015-07-29
-        # archived: true
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # blog_announcement_url: /blog/beta2-for-mars.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/f4/f4ffd0b36a622229e4a8b5c4db4c8c4fac0fd09750b1ba2cba73c22c5c0f5f83/jboss-devstudio-9.0.0.Beta2-installer-standalone.jar
-        #     file_size: 485MB
-        #   - name: Installer With EAP 6.4.0
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/32/329b93cc424feea6d396d9b9d69f508335c387a0780ee8fa880f5501919f6f65/jboss-devstudio-9.0.0.Beta2-installer-eap.jar
-        #     file_size: 630MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     file_size: 507MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/b7/b7289aa99840cd07fc7f51bf2deaa17f7ca9acaaf1a5b0e72adab85b286fe74d/jboss-devstudio-9.0.0.Beta2-updatesite-core.zip
-        #   - name: Target Platform for JBoss Developer Studio
-        #     file_size: 452MB
-        #     url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.0.0.Beta2-target-platform.zip
-        #   - name: JBoss Central Zip
-        #     file_size: 116MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/a8/a8402bfa51e56b272d3283b4b857c522e0a0443ee592503ba977705ed46914df/jboss-devstudio-9.0.0.Beta2-updatesite-central.zip
-        #   - name: Sources Zip
-        #     file_size: 332MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/2a/2a4be9db02604a2ccc471005fee6aa86c20d9c697b6d304fdb7d2bae68bb4970/jboss-devstudio-9.0.0.Beta2-src.zip
+        release_date: 2015-07-29
+        archived: true
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        blog_announcement_url: /blog/beta2-for-mars.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/f4/f4ffd0b36a622229e4a8b5c4db4c8c4fac0fd09750b1ba2cba73c22c5c0f5f83/jboss-devstudio-9.0.0.Beta2-installer-standalone.jar
+            file_size: 485MB
+          - name: Installer With EAP 6.4.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/32/329b93cc424feea6d396d9b9d69f508335c387a0780ee8fa880f5501919f6f65/jboss-devstudio-9.0.0.Beta2-installer-eap.jar
+            file_size: 630MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            file_size: 507MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/b7/b7289aa99840cd07fc7f51bf2deaa17f7ca9acaaf1a5b0e72adab85b286fe74d/jboss-devstudio-9.0.0.Beta2-updatesite-core.zip
+          - name: Target Platform for JBoss Developer Studio
+            file_size: 452MB
+            url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.0.0.Beta2-target-platform.zip
+          - name: JBoss Central Zip
+            file_size: 116MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/a8/a8402bfa51e56b272d3283b4b857c522e0a0443ee592503ba977705ed46914df/jboss-devstudio-9.0.0.Beta2-updatesite-central.zip
+          - name: Sources Zip
+            file_size: 332MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/2a/2a4be9db02604a2ccc471005fee6aa86c20d9c697b6d304fdb7d2bae68bb4970/jboss-devstudio-9.0.0.Beta2-src.zip
       9.0.0.Beta1:
-        # release_date: 2015-06-22
-        # archived: true
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # blog_announcement_url: /blog/2015-06-22-beta1-for-mars.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/8f/8f01d0db3cc193f7eb8876cc0c1ad0bcabbfb9a3b794837d572f52209e738908/jboss-devstudio-9.0.0.Beta1-installer-standalone.jar
-        #     file_size: 484MB
-        #   - name: Installer With EAP 6.4.0
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/3d/3d115879e3be646a563d05452c3a22bac394652e40260a3b43d9dd5c3ba7121e/jboss-devstudio-9.0.0.Beta1-installer-eap.jar
-        #     file_size: 628MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     file_size: 505MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/2c/2c92b68d122db901e3acbb74f06950116f4fe29402c25f4391761f9a93e65bba/jboss-devstudio-9.0.0.Beta1-updatesite-core.zip
-        #   - name: Target Platform for JBoss Developer Studio
-        #     file_size: 451MB
-        #     url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.0.0.Beta1-target-platform.zip
+        release_date: 2015-06-22
+        archived: true
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        blog_announcement_url: /blog/2015-06-22-beta1-for-mars.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/8f/8f01d0db3cc193f7eb8876cc0c1ad0bcabbfb9a3b794837d572f52209e738908/jboss-devstudio-9.0.0.Beta1-installer-standalone.jar
+            file_size: 484MB
+          - name: Installer With EAP 6.4.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/3d/3d115879e3be646a563d05452c3a22bac394652e40260a3b43d9dd5c3ba7121e/jboss-devstudio-9.0.0.Beta1-installer-eap.jar
+            file_size: 628MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            file_size: 505MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/2c/2c92b68d122db901e3acbb74f06950116f4fe29402c25f4391761f9a93e65bba/jboss-devstudio-9.0.0.Beta1-updatesite-core.zip
+          - name: Target Platform for JBoss Developer Studio
+            file_size: 451MB
+            url: https://devstudio.redhat.com/9.0/development/updates/core/jboss-devstudio-9.0.0.Beta1-target-platform.zip
     luna:
       8.1.0.GA:
         marketplace_url: http://marketplace.eclipse.org/node/1616973
@@ -370,49 +370,49 @@ devstudio:
             url: https://devstudio.jboss.com/static/updates/8.0.0/jboss-devstudio-8.1.0.GA-target-platform.zip
             md5_url: https://devstudio.jboss.com/static/updates/8.0.0/jboss-devstudio-8.1.0.GA-target-platform.zip.MD5
       8.1.0.CR1:
-        # release_date: 2015-03-20
-        # archived: true
-        # supported_devstudio_is_version: 8.0.0.GA
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # blog_announcement_url: /blog/2015-03-19-devstudio-8.1.0.CR1-for-luna.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/9d/9daef0477c4b1924ae360659d3beb5e0bb405d7d79f6ca785cd5779391bcb9a6/jboss-devstudio-8.1.0.CR1-installer-standalone.jar
-        #     file_size: 546MB
-        #   - name: Installer With EAP 6.3.0
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/ec/ec33cab4d5f7fdaffef12fed1dbcb167f73b09820194c290fe5ee1b01144bfa0/jboss-devstudio-8.1.0.CR1-installer-eap.jar
-        #     file_size: 685MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     file_size: 524MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/be/be4c0714df996ee1edd5b082b13c1bc1e10c857a388432de24b1de107913e1ff/jboss-devstudio-8.1.0.CR1-updatesite-core.zip
-        #   - name: Target Platform for JBoss Developer Studio
-        #     file_size: 426MB
-        #     url: https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.1.0.CR1-target-platform.zip
-        #     md5_url: https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.1.0.CR1-target-platform.zip.MD5
+        release_date: 2015-03-20
+        archived: true
+        supported_devstudio_is_version: 8.0.0.GA
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        blog_announcement_url: /blog/2015-03-19-devstudio-8.1.0.CR1-for-luna.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/9d/9daef0477c4b1924ae360659d3beb5e0bb405d7d79f6ca785cd5779391bcb9a6/jboss-devstudio-8.1.0.CR1-installer-standalone.jar
+            file_size: 546MB
+          - name: Installer With EAP 6.3.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/ec/ec33cab4d5f7fdaffef12fed1dbcb167f73b09820194c290fe5ee1b01144bfa0/jboss-devstudio-8.1.0.CR1-installer-eap.jar
+            file_size: 685MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            file_size: 524MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/be/be4c0714df996ee1edd5b082b13c1bc1e10c857a388432de24b1de107913e1ff/jboss-devstudio-8.1.0.CR1-updatesite-core.zip
+          - name: Target Platform for JBoss Developer Studio
+            file_size: 426MB
+            url: https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.1.0.CR1-target-platform.zip
+            md5_url: https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.1.0.CR1-target-platform.zip.MD5
       8.1.0.Beta1:
-        # release_date: 2015-03-04
-        # archived: true
-        # supported_devstudio_is_version: 8.0.0.GA
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # blog_announcement_url: /blog/2015-03-05-JBDS-8.1.0.Beta1-for-luna.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/8f/8f7b797dd0ff04a75801e34f6dea3627e89b0faf598144d06892f119eb64add1/jboss-devstudio-8.1.0.Beta1-installer-standalone.jar
-        #     file_size: 546MB
-        #   - name: Installer With EAP 6.3.0
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/a5/a5fd25450ba0b64c491fc9effab10351ed269cdc1ca90d0218d1d24496ab2b41/jboss-devstudio-8.1.0.Beta1-installer-eap.jar
-        #     file_size: 685MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     file_size: 524MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/5d/5d70ee2e8199a031152caf42b8a52b6d14b79b3f4960f03e6e8ad0341447ce37/jboss-devstudio-8.1.0.Beta1-updatesite-core.zip
-        #   - name: Target Platform for JBoss Developer Studio
-        #     file_size: 426MB
-        #     url: https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.1.0.Beta1-target-platform.zip
-        #     md5_url: https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.1.0.Beta1-target-platform.zip.MD5
+        release_date: 2015-03-04
+        archived: true
+        supported_devstudio_is_version: 8.0.0.GA
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        blog_announcement_url: /blog/2015-03-05-JBDS-8.1.0.Beta1-for-luna.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/8f/8f7b797dd0ff04a75801e34f6dea3627e89b0faf598144d06892f119eb64add1/jboss-devstudio-8.1.0.Beta1-installer-standalone.jar
+            file_size: 546MB
+          - name: Installer With EAP 6.3.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/a5/a5fd25450ba0b64c491fc9effab10351ed269cdc1ca90d0218d1d24496ab2b41/jboss-devstudio-8.1.0.Beta1-installer-eap.jar
+            file_size: 685MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            file_size: 524MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/5d/5d70ee2e8199a031152caf42b8a52b6d14b79b3f4960f03e6e8ad0341447ce37/jboss-devstudio-8.1.0.Beta1-updatesite-core.zip
+          - name: Target Platform for JBoss Developer Studio
+            file_size: 426MB
+            url: https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.1.0.Beta1-target-platform.zip
+            md5_url: https://devstudio.redhat.com/updates/8.0.0/jboss-devstudio-8.1.0.Beta1-target-platform.zip.MD5
       8.0.2.GA:
         archived: true
         documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
@@ -472,81 +472,81 @@ devstudio:
             url: https://www.jboss.org/download-manager/content/origin/files/sha256/da/da21079c31af1a7dd8ff7dc05a4003fa818307eb3cdad6e10139437b5022d161/jboss-devstudio-8.0.0.GA-v20141020-1042-B317-updatesite-core.zip
             #md5_url: n/a
       8.0.0.CR1:
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_date: 2014-09-18
-        # archived: true
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html
-        # blog_announcement_url: /blog/2014-09-17-CR1-for-luna.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/5a/5a748e631b667f78fd6c9bd6e8aa13e29d9b4731555762df191aad684d866759/jboss-devstudio-8.0.0.CR1-v20140915-0805-B246-installer-standalone.jar
-        #     file_size: 552MB
-        #   - name: Installer With EAP 6.3.0
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/1e/1e0b9468604aa20ac8c44b63cd651cfba2c97ccc7a0f6f4ebb23b90a6244b2f1/jboss-devstudio-8.0.0.CR1-v20140915-0805-B246-installer-eap.jar
-        #     file_size: 691MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     file_size: 514MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/ea/ea08cbdc79fa982989d578cbb1c39cc3e42dd36b5cee598411d3814d4148c96b/jboss-devstudio-8.0.0.CR1-v20140915-0805-B246-updatesite-core.zip
-        #     #md5_url: n/a
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_date: 2014-09-18
+        archived: true
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html
+        blog_announcement_url: /blog/2014-09-17-CR1-for-luna.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/5a/5a748e631b667f78fd6c9bd6e8aa13e29d9b4731555762df191aad684d866759/jboss-devstudio-8.0.0.CR1-v20140915-0805-B246-installer-standalone.jar
+            file_size: 552MB
+          - name: Installer With EAP 6.3.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/1e/1e0b9468604aa20ac8c44b63cd651cfba2c97ccc7a0f6f4ebb23b90a6244b2f1/jboss-devstudio-8.0.0.CR1-v20140915-0805-B246-installer-eap.jar
+            file_size: 691MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            file_size: 514MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/ea/ea08cbdc79fa982989d578cbb1c39cc3e42dd36b5cee598411d3814d4148c96b/jboss-devstudio-8.0.0.CR1-v20140915-0805-B246-updatesite-core.zip
+            #md5_url: n/a
       8.0.0.Beta3:
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_date: 2014-07-28
-        # archived: true
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html
-        # blog_announcement_url: /blog/2014-07-28-beta3-for-luna.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/96/96d6ab7107c64283b9e92396f046ccec3301b263df81bd8b3a9abf4e7934deb9/jboss-devstudio-8.0.0.Beta3-v20140722-2011-B194-installer-standalone.jar
-        #     file_size: 504MB
-        #   - name: Installer With EAP 6.3.0.Beta
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/09/0998b448383eca6e74c86ac58d4a1b88c066a0a39e25b12df8ebb6a2ed72ba73/jboss-devstudio-8.0.0.Beta3-v20140722-2011-B194-installer-eap.jar
-        #     file_size: 643MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     file_size: 850MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/4a/4ad3df66a4e019827ad53681b7d3bea33a126230ce7e90b4195f1e13f9aba684/jboss-devstudio-8.0.0.Beta3-v20140722-2011-B194-updatesite-core.zip
-        #     #md5_url: n/a
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_date: 2014-07-28
+        archived: true
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html
+        blog_announcement_url: /blog/2014-07-28-beta3-for-luna.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/96/96d6ab7107c64283b9e92396f046ccec3301b263df81bd8b3a9abf4e7934deb9/jboss-devstudio-8.0.0.Beta3-v20140722-2011-B194-installer-standalone.jar
+            file_size: 504MB
+          - name: Installer With EAP 6.3.0.Beta
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/09/0998b448383eca6e74c86ac58d4a1b88c066a0a39e25b12df8ebb6a2ed72ba73/jboss-devstudio-8.0.0.Beta3-v20140722-2011-B194-installer-eap.jar
+            file_size: 643MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            file_size: 850MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/4a/4ad3df66a4e019827ad53681b7d3bea33a126230ce7e90b4195f1e13f9aba684/jboss-devstudio-8.0.0.Beta3-v20140722-2011-B194-updatesite-core.zip
+            #md5_url: n/a
 
       8.0.0.Beta2:
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_date: 2014-06-20
-        # archived: true
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html
-        # blog_announcement_url: /blog/2014-06-19-beta2-for-luna.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/3c/3c4508c0c43f9aae305c289b946cfc963b8be01678dc9d538b9847872fa80ef6/jboss-devstudio-8.0.0.Beta2-v20140617-2058-B166-installer-standalone.jar
-        #     file_size: 550MB
-        #   - name: Installer With EAP 6.2.0
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/41/41bbfb910533778ac059a5fceafd814b06cc7e0b34086ef76c302cbddc687f0f/jboss-devstudio-8.0.0.Beta2-v20140617-2058-B166-installer-eap.jar
-        #     file_size: 676MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     file_size: 850MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/9d/9da04d293283afcff48c85d382e4f57dccce181382aa556e9b44d38f5cadf94a/jboss-devstudio-8.0.0.Beta2-v20140617-2058-B166-updatesite-core.zip
-        #     #md5_url: n/a
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_date: 2014-06-20
+        archived: true
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html
+        blog_announcement_url: /blog/2014-06-19-beta2-for-luna.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/3c/3c4508c0c43f9aae305c289b946cfc963b8be01678dc9d538b9847872fa80ef6/jboss-devstudio-8.0.0.Beta2-v20140617-2058-B166-installer-standalone.jar
+            file_size: 550MB
+          - name: Installer With EAP 6.2.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/41/41bbfb910533778ac059a5fceafd814b06cc7e0b34086ef76c302cbddc687f0f/jboss-devstudio-8.0.0.Beta2-v20140617-2058-B166-installer-eap.jar
+            file_size: 676MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            file_size: 850MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/9d/9da04d293283afcff48c85d382e4f57dccce181382aa556e9b44d38f5cadf94a/jboss-devstudio-8.0.0.Beta2-v20140617-2058-B166-updatesite-core.zip
+            #md5_url: n/a
       8.0.0.Beta1:
-        # release_date: 2014-04-11
-        # archived: true
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
-        # release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html
-        # blog_announcement_url: /blog/2014-04-14-beta1-for-luna.html
-        # installers:
-        #   - name: Stand-alone Installer
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/25/2550fbb912f42b6c0e60d124cc0d5b7c1a26b1767e27a0ecd6f2b9c36f3b3d9a/jbdevstudio-product-universal-8.0.0.Beta1-v20140408-2350-B93.jar
-        #     file_size: 482MB
-        #   - name: Installer With EAP 6.2.0
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/5f/5f7a06b642bf212a89c9526b2e477bab33cc9aa6b0bb2bb63e8e23e5586b4266/jbdevstudio-product-eap-universal-8.0.0.Beta1-v20140408-2350-B93.jar
-        #     file_size: 609MB
-        # zips:
-        #   - name: Update site (including sources) bundle of JBoss Developer Studio
-        #     file_size: 725MB
-        #     url: https://www.jboss.org/download-manager/content/origin/files/sha256/b9/b9a4d822294c7457522238e81335b8dc5013e9835ce9b1837e4a5be241b6d4c3/jbdevstudio-product-Update-8.0.0.Beta1-v20140408-2350-B93.zip
-        #     #md5_url: n/a
+        release_date: 2014-04-11
+        archived: true
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/
+        release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio/8.0/html/8.0.0_Release_Notes/index.html
+        blog_announcement_url: /blog/2014-04-14-beta1-for-luna.html
+        installers:
+          - name: Stand-alone Installer
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/25/2550fbb912f42b6c0e60d124cc0d5b7c1a26b1767e27a0ecd6f2b9c36f3b3d9a/jbdevstudio-product-universal-8.0.0.Beta1-v20140408-2350-B93.jar
+            file_size: 482MB
+          - name: Installer With EAP 6.2.0
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/5f/5f7a06b642bf212a89c9526b2e477bab33cc9aa6b0bb2bb63e8e23e5586b4266/jbdevstudio-product-eap-universal-8.0.0.Beta1-v20140408-2350-B93.jar
+            file_size: 609MB
+        zips:
+          - name: Update site (including sources) bundle of JBoss Developer Studio
+            file_size: 725MB
+            url: https://www.jboss.org/download-manager/content/origin/files/sha256/b9/b9a4d822294c7457522238e81335b8dc5013e9835ce9b1837e4a5be241b6d4c3/jbdevstudio-product-Update-8.0.0.Beta1-v20140408-2350-B93.zip
+            #md5_url: n/a
     kepler:
       7.1.1.GA:
         release_date: 2014-03-24
@@ -658,15 +658,15 @@ devstudio_is:
             url: https://devstudio.redhat.com/10.0/stable/updates/integration-stack/devstudio-integration-stack-10.0.0.GA-updatesite-earlyaccess.zip
             md5_url: https://devstudio.redhat.com/10.0/stable/updates/integration-stack/devstudio-integration-stack-10.0.0.GA-updatesite-earlyaccess.zip.MD5
       10.0.0.Alpha1:
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/
-        # release_date: 2016-09-27
-        # required_devstudio_version: 10.1.0.GA
-        # update_site_url: https://devstudio.redhat.com/10.0/development/updates/integration-stack/earlyaccess
-        # zips:
-        #   - name: Update site bundle of JBoss Developer Studio Integration Stack (Early Access)
-        #     file_size: 337MB
-        #     url: https://devstudio.redhat.com/10.0/development/updates/integration-stack/devstudio-integration-stack-10.0.0.Alpha1-earlyaccess.zip
-        #     md5_url: https://devstudio.redhat.com/10.0/development/updates/integration-stack/devstudio-integration-stack-10.0.0.Alpha1-earlyaccess.zip.MD5
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/
+        release_date: 2016-09-27
+        required_devstudio_version: 10.1.0.GA
+        update_site_url: https://devstudio.redhat.com/10.0/development/updates/integration-stack/earlyaccess
+        zips:
+          - name: Update site bundle of JBoss Developer Studio Integration Stack (Early Access)
+            file_size: 337MB
+            url: https://devstudio.redhat.com/10.0/development/updates/integration-stack/devstudio-integration-stack-10.0.0.Alpha1-earlyaccess.zip
+            md5_url: https://devstudio.redhat.com/10.0/development/updates/integration-stack/devstudio-integration-stack-10.0.0.Alpha1-earlyaccess.zip.MD5
     mars:
       9.0.3.GA:
         documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0
@@ -733,32 +733,32 @@ devstudio_is:
             url: https://devstudio.redhat.com/9.0/stable/updates/integration-stack/devstudio-integration-stack-9.0.0.GA-earlyaccess.zip
             md5_url: https://devstudio.redhat.com/9.0/stable/updates/integration-stack/devstudio-integration-stack-9.0.0.GA-earlyaccess.zip.MD5
       9.0.0.Beta1:
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0
-        # release_notes_url: https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0-Beta1/html/9.0.0_Beta1_Release_Notes/index.html
-        # release_date: 2016-03-11
-        # required_devstudio_version: 9.1.0.Beta2
-        # update_site_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/earlyaccess
-        # blog_announcement_url: /blog/integration-stack-4.3.0.Beta1-for-mars.html
-        # zips:
-        #   - name: Update site bundle of JBoss Developer Studio Integration Stack (Early Access)
-        #     file_size: 307MB
-        #     url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Beta1-earlyaccess.zip
-        #     md5_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Beta1-earlyaccess.zip.MD5
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0
+        release_notes_url: https://access.redhat.com/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0-Beta1/html/9.0.0_Beta1_Release_Notes/index.html
+        release_date: 2016-03-11
+        required_devstudio_version: 9.1.0.Beta2
+        update_site_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/earlyaccess
+        blog_announcement_url: /blog/integration-stack-4.3.0.Beta1-for-mars.html
+        zips:
+          - name: Update site bundle of JBoss Developer Studio Integration Stack (Early Access)
+            file_size: 307MB
+            url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Beta1-earlyaccess.zip
+            md5_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Beta1-earlyaccess.zip.MD5
       9.0.0.Alpha2:
-        # documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0
-        # #release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/8.0/html/8.0.3_Release_Notes/index.html
-        # release_date: 2015-10-12
-        # required_devstudio_version: 9.0.0.GA
-        # update_site_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/
-        # zips:
-        #   - name: Update site bundle of JBoss Developer Studio Integration Stack
-        #     file_size: 53MB
-        #     url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Alpha2.zip
-        #     md5_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Alpha2.zip.MD5
-        #   - name: Update site bundle of JBoss Developer Studio Integration Stack (Early Access)
-        #     file_size: 326MB
-        #     url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Alpha2-earlyaccess.zip
-        #     md5_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Alpha2-earlyaccess.zip.MD5
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/9.0
+        #release_notes_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/8.0/html/8.0.3_Release_Notes/index.html
+        release_date: 2015-10-12
+        required_devstudio_version: 9.0.0.GA
+        update_site_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/
+        zips:
+          - name: Update site bundle of JBoss Developer Studio Integration Stack
+            file_size: 53MB
+            url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Alpha2.zip
+            md5_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Alpha2.zip.MD5
+          - name: Update site bundle of JBoss Developer Studio Integration Stack (Early Access)
+            file_size: 326MB
+            url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Alpha2-earlyaccess.zip
+            md5_url: https://devstudio.redhat.com/9.0/development/updates/integration-stack/devstudio-integration-stack-9.0.0.Alpha2-earlyaccess.zip.MD5
     luna:
       8.0.7.GA:
         documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/8.0
@@ -863,27 +863,27 @@ devstudio_is:
             url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.GA.zip
             md5_url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.GA.zip.MD5
       8.0.0.Beta2:
-        # blog_announcement_url: /blog/2015-01-13-JBTIS-Beta2-for-luna.html
-        # #release_notes_url: https://devstudio.jboss.com/updates/8.0/integration-stack/release-notes/Release_Notes_8.0.0.html
-        # release_date: 2015-01-12
-        # required_devstudio_version: 8.0.1.GA
-        # update_site_url: https://devstudio.jboss.com/updates/8.0-development/integration-stack/
-        # zips:
-        #   - name: Update site bundle of JBoss Developer Studio Integration Stack
-        #     file_size: 294MB
-        #     url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.Beta2a.zip
-        #     md5_url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.Beta2a.zip.MD5
+        blog_announcement_url: /blog/2015-01-13-JBTIS-Beta2-for-luna.html
+        #release_notes_url: https://devstudio.jboss.com/updates/8.0/integration-stack/release-notes/Release_Notes_8.0.0.html
+        release_date: 2015-01-12
+        required_devstudio_version: 8.0.1.GA
+        update_site_url: https://devstudio.jboss.com/updates/8.0-development/integration-stack/
+        zips:
+          - name: Update site bundle of JBoss Developer Studio Integration Stack
+            file_size: 294MB
+            url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.Beta2a.zip
+            md5_url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.Beta2a.zip.MD5
       8.0.0.Beta1:
-        # blog_announcement_url: /blog/2014-11-13-JBTIS-Beta1-for-luna.html
-        # #release_notes_url: https://devstudio.jboss.com/updates/8.0/integration-stack/release-notes/Release_Notes_8.0.0.html
-        # release_date: 2014-11-12
-        # required_devstudio_version: 8.0.0.GA
-        # update_site_url: https://devstudio.jboss.com/updates/8.0-development/integration-stack/
-        # zips:
-        #   - name: Update site bundle of JBoss Developer Studio Integration Stack
-        #     file_size: 352MB
-        #     url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.Beta1.zip
-        #     md5_url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.Beta1.zip.MD5
+        blog_announcement_url: /blog/2014-11-13-JBTIS-Beta1-for-luna.html
+        #release_notes_url: https://devstudio.jboss.com/updates/8.0/integration-stack/release-notes/Release_Notes_8.0.0.html
+        release_date: 2014-11-12
+        required_devstudio_version: 8.0.0.GA
+        update_site_url: https://devstudio.jboss.com/updates/8.0-development/integration-stack/
+        zips:
+          - name: Update site bundle of JBoss Developer Studio Integration Stack
+            file_size: 352MB
+            url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.Beta1.zip
+            md5_url: https://devstudio.jboss.com/updates/8.0.0/jbdevstudio-integration-stack-updatesite-8.0.0.Beta1.zip.MD5
     kepler:
       7.1.0.GA:
         build_type: stable
@@ -998,66 +998,67 @@ jbt_core:
           - name: Release Notes
             url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.4.2.AM3:
-        # release_date: 2016-11-10
-        # supported_jbt_is_version: 4.4.0.Final
-        # blog_announcement_url: /blog/am3.4.4.2.neon.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 474MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 244MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 17MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        release_date: 2016-11-10
+        supported_jbt_is_version: 4.4.0.Final
+        blog_announcement_url: /blog/am3.4.4.2.neon.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 474MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 244MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 17MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM3-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.4.2.AM2:
-        # release_date: 2016-10-19
-        # supported_jbt_is_version: 4.4.0.Final
-        # blog_announcement_url: /blog/am2.4.4.2.neon.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 474MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 244MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 17MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        release_date: 2016-10-19
+        supported_jbt_is_version: 4.4.0.Final
+        blog_announcement_url: /blog/am2.4.4.2.neon.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 474MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 244MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 17MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM2-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.4.2.AM1:
-        # release_date: 2016-09-29
-        # supported_jbt_is_version: 4.4.0.Final
-        # blog_announcement_url: /blog/am1-for-neon.1.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 474MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 244MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 17MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        release_date: 2016-09-29
+        supported_jbt_is_version: 4.4.0.Final
+        blog_announcement_url: /blog/am1-for-neon.1.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 474MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 244MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 17MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.2.AM1-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.4.1.Final:
+        archived: true
         update_site_url: http://download.jboss.org/jbosstools/neon/stable/updates/
         marketplace_url: https://marketplace.eclipse.org/node/1617241
         marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=1617241
@@ -1081,49 +1082,49 @@ jbt_core:
           - name: Release Notes
             url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.4.1.AM3:
-        # update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/
-        # archived: true
-        # release_date: 2016-08-17
-        # supported_jbt_is_version: 4.3.0.Final
-        # blog_announcement_url: /blog/am3-for-neon.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 456MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 244MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 17MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/
+        archived: true
+        release_date: 2016-08-17
+        supported_jbt_is_version: 4.3.0.Final
+        blog_announcement_url: /blog/am3-for-neon.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 456MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 244MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 17MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM3-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.4.1.AM2:
-        # update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/
-        # archived: true
-        # release_date: 2016-07-29
-        # supported_jbt_is_version: 4.3.0.Final
-        # blog_announcement_url: /blog/am2-for-neon.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 456MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 244MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 17MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/
+        archived: true
+        release_date: 2016-07-29
+        supported_jbt_is_version: 4.3.0.Final
+        blog_announcement_url: /blog/am2-for-neon.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 456MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 244MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 17MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.1.AM2-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.4.0.Final:
         update_site_url: http://download.jboss.org/jbosstools/neon/stable/updates/
         archived: true
@@ -1147,26 +1148,26 @@ jbt_core:
           - name: Release Notes
             url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.4.0.Alpha2:
-        # update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/
-        # archived: true
-        # release_date: 2016-05-25
-        # blog_announcement_url: /blog/alpha-for-neon.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 426MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 222MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 17MB
-        #     url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/
+        archived: true
+        release_date: 2016-05-25
+        blog_announcement_url: /blog/alpha-for-neon.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 426MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 222MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 17MB
+            url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/neon/development/updates/core/jbosstools-4.4.0.Alpha2-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
 
     mars:
       4.3.1.Final:
@@ -1193,48 +1194,48 @@ jbt_core:
           - name: Release Notes
             url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.3.1.Beta2:
-        # update_site_url: http://download.jboss.org/jbosstools/mars/stable/updates/
-        # archived: true
-        # release_date: 2016-02-02
-        # supported_jbt_is_version: 4.3.0.Beta1
-        # blog_announcement_url: /blog/beta2-for-mars2.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 398MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 222MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 16MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        update_site_url: http://download.jboss.org/jbosstools/mars/stable/updates/
+        archived: true
+        release_date: 2016-02-02
+        supported_jbt_is_version: 4.3.0.Beta1
+        blog_announcement_url: /blog/beta2-for-mars2.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 398MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 222MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 16MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta2-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.3.1.Beta1:
-        # archived: true
-        # release_date: 2015-12-21
-        # supported_jbt_is_version: 4.3.0.Alpha2
-        # blog_announcement_url: /blog/beta1-for-mars2.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 395MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 222MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 16MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        archived: true
+        release_date: 2015-12-21
+        supported_jbt_is_version: 4.3.0.Alpha2
+        blog_announcement_url: /blog/beta1-for-mars2.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 395MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 222MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 16MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.1.Beta1-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.3.0.Final:
         archived: true
         release_date: 2015-10-06
@@ -1257,122 +1258,122 @@ jbt_core:
           - name: Release Notes
             url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.3.0.CR1:
-        # release_date: 2015-09-22
-        # archived: true
-        # blog_announcement_url: /blog/cr1-for-mars.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 389MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 389MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 16MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        release_date: 2015-09-22
+        archived: true
+        blog_announcement_url: /blog/cr1-for-mars.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 389MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 389MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 16MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.CR1-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.3.0.Beta2:
-        # release_date: 2015-07-28
-        # archived: true
-        # blog_announcement_url: /blog/beta2-for-mars.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # # as of Beta2, publish to dl.jb.org instead of Sourceforge
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 384MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-updatesite-core.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-updatesite-core.zip.sha256
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 361MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-src.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-src.zip.sha256
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 16.6MB
-        #     url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-browsersim-standalone.zip
-        #     sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-browsersim-standalone.zip.sha256
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        release_date: 2015-07-28
+        archived: true
+        blog_announcement_url: /blog/beta2-for-mars.html
+        documentation_url: http://docs.jboss.org/tools/
+        # as of Beta2, publish to dl.jb.org instead of Sourceforge
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 384MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-updatesite-core.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-updatesite-core.zip.sha256
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 361MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-src.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-src.zip.sha256
+          - name: Stand-alone BrowserSim
+            file_size: 16.6MB
+            url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/static/mars/development/updates/core/jbosstools-4.3.0.Beta2-browsersim-standalone.zip.sha256
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.3.0.Beta1:
-        # release_date: 2015-06-22
-        # archived: true
-        # blog_announcement_url: /blog/2015-06-22-beta1-for-mars.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 401MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-18_21-49-21-B59-updatesite-core.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-18_21-49-21-B59-updatesite-core.zip.sha1
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 299MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-18_21-49-21-B59-src.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-18_21-49-21-B59-src.zip.sha1
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 16.6MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-05_01-14-40-B10-browsersim-standalone.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-05_01-14-40-B10-browsersim-standalone.zip.sha1
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        release_date: 2015-06-22
+        archived: true
+        blog_announcement_url: /blog/2015-06-22-beta1-for-mars.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 401MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-18_21-49-21-B59-updatesite-core.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-18_21-49-21-B59-updatesite-core.zip.sha1
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 299MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-18_21-49-21-B59-src.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-18_21-49-21-B59-src.zip.sha1
+          - name: Stand-alone BrowserSim
+            file_size: 16.6MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-05_01-14-40-B10-browsersim-standalone.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Beta1_2015-06-05_01-14-40-B10-browsersim-standalone.zip.sha1
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.3.0.Alpha2:
-        # release_date: 2015-04-27
-        # archived: true
-        # blog_announcement_url: /blog/2015-04-28-alpha2-for-mars.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 378MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha2_2015-04-20_11-16-43-B32-updatesite-core.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha2_2015-04-20_11-16-43-B32-updatesite-core.zip.MD5
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 16MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha2_2015-04-21_14-02-11-B6-browsersim-standalone.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha2_2015-04-21_14-02-11-B6-browsersim-standalone.zip.MD5
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
+        release_date: 2015-04-27
+        archived: true
+        blog_announcement_url: /blog/2015-04-28-alpha2-for-mars.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 378MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha2_2015-04-20_11-16-43-B32-updatesite-core.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha2_2015-04-20_11-16-43-B32-updatesite-core.zip.MD5
+          - name: Stand-alone BrowserSim
+            file_size: 16MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha2_2015-04-21_14-02-11-B6-browsersim-standalone.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha2_2015-04-21_14-02-11-B6-browsersim-standalone.zip.MD5
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
       4.3.0.Alpha1:
-        # release_date: 2015-02-20
-        # archived: true
-        # blog_announcement_url: /blog/2015-02-23-alpha1-for-mars.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 394MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-updatesite-core.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-updatesite-core.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 33.2kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-src.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-src.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 60.1MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_15-01-49-B8-updatesite-hibernatetools.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_15-01-49-B8-updatesite-hibernatetools.zip.MD5
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 16.1MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-browsersim-standalone.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-browsersim-standalone.zip.MD5
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/index.html
-      # 4.3.x.Nightly:
-        # update_site_url: http://download.jboss.org/jbosstools/mars/snapshots/updates/
-        # zips:
-          # - name: Stand-alone BrowserSim
-            # file_size: 16MB
-            # url: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jboss.tools.browsersim&a=org.jboss.tools.browsersim-standalone&v=3.7.1-SNAPSHOT&e=zip
-            # url: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jboss.tools.vpe.browsersim&a=org.jboss.tools.vpe.browsersim-standalone&v=3.7.0-SNAPSHOT&e=zip&c=standalone
-            #url: http://download.jboss.org/jbosstools/mars/snapshots/builds/jbosstools-browsersim-standalone_4.3.mars/latest/jbosstools-4.3.0.Final-browsersim-standalone.zip
-            #sha256_url: http://download.jboss.org/jbosstools/mars/snapshots/builds/jbosstools-browsersim-standalone_4.3.mars/latest/jbosstools-4.3.0.Final-browsersim-standalone.zip.sha256
+        release_date: 2015-02-20
+        archived: true
+        blog_announcement_url: /blog/2015-02-23-alpha1-for-mars.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 394MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-updatesite-core.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-updatesite-core.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 33.2kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-src.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-src.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 60.1MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_15-01-49-B8-updatesite-hibernatetools.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_15-01-49-B8-updatesite-hibernatetools.zip.MD5
+          - name: Stand-alone BrowserSim
+            file_size: 16.1MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-browsersim-standalone.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.3.0.x/jbosstools-4.3.0.Alpha1_2015-02-15_14-44-55-B13-browsersim-standalone.zip.MD5
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/index.html
+      4.3.x.Nightly:
+        update_site_url: http://download.jboss.org/jbosstools/mars/snapshots/updates/
+        zips:
+          - name: Stand-alone BrowserSim
+            file_size: 16MB
+            url: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jboss.tools.browsersim&a=org.jboss.tools.browsersim-standalone&v=3.7.1-SNAPSHOT&e=zip
+            url: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.jboss.tools.vpe.browsersim&a=org.jboss.tools.vpe.browsersim-standalone&v=3.7.0-SNAPSHOT&e=zip&c=standalone
+            url: http://download.jboss.org/jbosstools/mars/snapshots/builds/jbosstools-browsersim-standalone_4.3.mars/latest/jbosstools-4.3.0.Final-browsersim-standalone.zip
+            sha256_url: http://download.jboss.org/jbosstools/mars/snapshots/builds/jbosstools-browsersim-standalone_4.3.mars/latest/jbosstools-4.3.0.Final-browsersim-standalone.zip.sha256
 
     luna:
       4.2.3.Final:
         update_site_url: http://download.jboss.org/jbosstools/updates/stable/luna/
         marketplace_url: http://marketplace.eclipse.org/node/1617241
         marketplace_install_url: http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=1617241
-        archived: false
+        archived: true
         release_date: 2015-04-02
         supported_jbt_is_version: 4.2.7.Final
         blog_announcement_url: /blog/2015-04-02-devstudio-8.1.0.GA-for-luna.html
@@ -1397,55 +1398,55 @@ jbt_core:
           - name: Release Notes
             url: https://tools.jboss.org/documentation/whatsnew/jbosstools/4.2.3.Final.html
       4.2.3.CR1:
-        # archived: true
-        # release_date: 2015-03-19
-        # supported_jbt_is_version: 4.2.0.Final
-        # blog_announcement_url: /blog/2015-03-19-devstudio-8.1.0.CR1-for-luna.html
-        # documentation_url: https://tools.jboss.org/documentation/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 525MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_07-45-25-B363-updatesite-core.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_07-45-25-B363-updatesite-core.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 37.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_07-45-25-B363-src.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_07-45-25-B363-src.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 105MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_08-49-30-B257-updatesite-hibernatetools.zip.MD5
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_08-49-30-B257-updatesite-hibernatetools.zip.MD5
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 15.8MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-browsersim-standalone.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-browsersim-standalone.zip.MD5
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/jbosstools/4.2.3.CR1.html
+        archived: true
+        release_date: 2015-03-19
+        supported_jbt_is_version: 4.2.0.Final
+        blog_announcement_url: /blog/2015-03-19-devstudio-8.1.0.CR1-for-luna.html
+        documentation_url: https://tools.jboss.org/documentation/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 525MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_07-45-25-B363-updatesite-core.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_07-45-25-B363-updatesite-core.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 37.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_07-45-25-B363-src.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_07-45-25-B363-src.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 105MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_08-49-30-B257-updatesite-hibernatetools.zip.MD5
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.CR1_2015-03-14_08-49-30-B257-updatesite-hibernatetools.zip.MD5
+          - name: Stand-alone BrowserSim
+            file_size: 15.8MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-browsersim-standalone.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-browsersim-standalone.zip.MD5
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/jbosstools/4.2.3.CR1.html
       4.2.3.Beta1:
-        # archived: true
-        # release_date: 2015-03-04
-        # supported_jbt_is_version: 4.2.0.Final
-        # blog_announcement_url: /blog/2015-03-05-JBDS-8.1.0.Beta1-for-luna.html
-        # documentation_url: https://tools.jboss.org/documentation/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 525MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-updatesite-core.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-updatesite-core.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 37.1MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-src.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-src.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 105MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_14-25-34-B252-updatesite-hibernatetools.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_14-25-34-B252-updatesite-hibernatetools.zip.MD5
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 15.8MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-browsersim-standalone.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-browsersim-standalone.zip.MD5
-        #   - name: Release Notes
-        #     url: https://tools.jboss.org/documentation/whatsnew/jbosstools/4.2.3.Beta1.html
+        archived: true
+        release_date: 2015-03-04
+        supported_jbt_is_version: 4.2.0.Final
+        blog_announcement_url: /blog/2015-03-05-JBDS-8.1.0.Beta1-for-luna.html
+        documentation_url: https://tools.jboss.org/documentation/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 525MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-updatesite-core.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-updatesite-core.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 37.1MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-src.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-src.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 105MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_14-25-34-B252-updatesite-hibernatetools.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_14-25-34-B252-updatesite-hibernatetools.zip.MD5
+          - name: Stand-alone BrowserSim
+            file_size: 15.8MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-browsersim-standalone.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.3.x/jbosstools-4.2.3.Beta1_2015-03-01_13-40-40-B357-browsersim-standalone.zip.MD5
+          - name: Release Notes
+            url: https://tools.jboss.org/documentation/whatsnew/jbosstools/4.2.3.Beta1.html
       4.2.2.Final:
         archived: true
         release_date: 2015-01-21
@@ -1522,131 +1523,131 @@ jbt_core:
           - name: Release Notes
             url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.x/zz_Release_Notes_4.2.0.Final.readme.html
       4.2.0.CR1:
-        # archived: true
-        # release_date: 2014-09-17
-        # blog_announcement_url: /blog/2014-09-17-CR1-for-luna.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 516MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-14_02-42-22-B242-updatesite-core.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-14_02-42-22-B242-updatesite-core.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 36MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-14_02-42-22-B242-src.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-14_02-42-22-B242-src.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 104MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-15_02-47-21-B157-updatesite-hibernatetools.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-15_02-47-21-B157-updatesite-hibernatetools.zip.MD5
-        #   - name: Stand-alone BrowserSim
-        #     file_size: 15MB
-        #     url: http://download.jboss.org/jbosstools/builds/development/jbosstools-4.2.0.CR2-browsersim-standalone/jbosstools-4.2.0.CR2-browsersim-standalone.zip
-        #     #md5_url: .MD5
-        #   - name: Release Notes
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.x/zz_Release_Notes_4.2.0.CR1.readme.html
+        archived: true
+        release_date: 2014-09-17
+        blog_announcement_url: /blog/2014-09-17-CR1-for-luna.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 516MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-14_02-42-22-B242-updatesite-core.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-14_02-42-22-B242-updatesite-core.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 36MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-14_02-42-22-B242-src.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-14_02-42-22-B242-src.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 104MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-15_02-47-21-B157-updatesite-hibernatetools.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.CR1_2014-09-15_02-47-21-B157-updatesite-hibernatetools.zip.MD5
+          - name: Stand-alone BrowserSim
+            file_size: 15MB
+            url: http://download.jboss.org/jbosstools/builds/development/jbosstools-4.2.0.CR2-browsersim-standalone/jbosstools-4.2.0.CR2-browsersim-standalone.zip
+            #md5_url: .MD5
+          - name: Release Notes
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.x/zz_Release_Notes_4.2.0.CR1.readme.html
       4.2.0.Beta3:
-        # archived: true
-        # release_date: 2014-07-28
-        # blog_announcement_url: /blog/2014-07-28-beta3-for-luna.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 513MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_15-40-19-B198-updatesite-core.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_15-40-19-B198-updatesite-core.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 42MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_15-40-19-B198-src.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_15-40-19-B198-src.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 96MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_16-09-46-B136-updatesite-hibernatetools.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_16-09-46-B136-updatesite-hibernatetools.zip.MD5
-        #   - name: Release Notes
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/zz_Release_Notes_4.2.0.Beta3.readme.html
+        archived: true
+        release_date: 2014-07-28
+        blog_announcement_url: /blog/2014-07-28-beta3-for-luna.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 513MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_15-40-19-B198-updatesite-core.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_15-40-19-B198-updatesite-core.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 42MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_15-40-19-B198-src.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_15-40-19-B198-src.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 96MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_16-09-46-B136-updatesite-hibernatetools.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta3_2014-07-22_16-09-46-B136-updatesite-hibernatetools.zip.MD5
+          - name: Release Notes
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/zz_Release_Notes_4.2.0.Beta3.readme.html
       4.2.0.Beta2:
-        # archived: true
-        # release_date: 2014-06-19
-        # blog_announcement_url: /blog/2014-06-19-beta2-for-luna.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 497MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-43-46-B174-updatesite-core.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-43-46-B174-updatesite-core.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 40MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-43-46-B174-src.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-43-46-B174-src.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 96MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-57-53-B113-updatesite-hibernatetools.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-57-53-B113-updatesite-hibernatetools.zip.MD5
-        #   - name: Release Notes
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/zz_Release_Notes_4.2.0.Beta2.readme.html
+        archived: true
+        release_date: 2014-06-19
+        blog_announcement_url: /blog/2014-06-19-beta2-for-luna.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 497MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-43-46-B174-updatesite-core.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-43-46-B174-updatesite-core.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 40MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-43-46-B174-src.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-43-46-B174-src.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 96MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-57-53-B113-updatesite-hibernatetools.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/jbosstools-4.2.0.Beta2_2014-06-17_16-57-53-B113-updatesite-hibernatetools.zip.MD5
+          - name: Release Notes
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/jbosstools4.2.0.x/zz_Release_Notes_4.2.0.Beta2.readme.html
       4.2.0.Beta1:
-        # archived: true
-        # release_date: 2014-04-11
-        # blog_announcement_url: /blog/2014-04-14-beta1-for-luna.html
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 460MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Beta1_2014-04-08_19-15-41-B105.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Beta1_2014-04-08_19-15-41-B105.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 28KB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Beta1_2014-04-08_19-15-41-B105.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Beta1_2014-04-08_19-15-41-B105.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 80MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Beta1_2014-04-08_19-49-44-B47.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Beta1_2014-04-08_19-49-44-B47.zip.MD5
-        #   - name: Release Notes
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/zz_Release_Notes_4.2.0.Beta1.readme.html
+        archived: true
+        release_date: 2014-04-11
+        blog_announcement_url: /blog/2014-04-14-beta1-for-luna.html
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 460MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Beta1_2014-04-08_19-15-41-B105.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Beta1_2014-04-08_19-15-41-B105.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 28KB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Beta1_2014-04-08_19-15-41-B105.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Beta1_2014-04-08_19-15-41-B105.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 80MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Beta1_2014-04-08_19-49-44-B47.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Beta1_2014-04-08_19-49-44-B47.zip.MD5
+          - name: Release Notes
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/zz_Release_Notes_4.2.0.Beta1.readme.html
       4.2.0.Alpha2:
-        # archived: true
-        # release_date: 2014-02-14
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 441MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Alpha2_2014-02-14_09-54-39-B84.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Alpha2_2014-02-14_09-54-39-B84.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 24KB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Alpha2_2014-02-14_09-54-39-B84.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Alpha2_2014-02-14_09-54-39-B84.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 66MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Alpha2_2014-02-10_02-48-32-B13.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Alpha2_2014-02-10_02-48-32-B13.zip.MD5
-        #   - name: Release Notes
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/zz_Release_Notes_4.2.0.Alpha2.readme.html
+        archived: true
+        release_date: 2014-02-14
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 441MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Alpha2_2014-02-14_09-54-39-B84.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Alpha2_2014-02-14_09-54-39-B84.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 24KB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Alpha2_2014-02-14_09-54-39-B84.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Alpha2_2014-02-14_09-54-39-B84.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 66MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Alpha2_2014-02-10_02-48-32-B13.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Alpha2_2014-02-10_02-48-32-B13.zip.MD5
+          - name: Release Notes
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/zz_Release_Notes_4.2.0.Alpha2.readme.html
       4.2.0.Alpha1:
-        # archived: true
-        # release_date: 2013-12-19
-        # documentation_url: http://docs.jboss.org/tools/
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 417MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 93MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 77MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip.MD5
-        #   - name: Release Notes
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/zz_Release_Notes_4.2.0.Alpha1.readme.html
+        archived: true
+        release_date: 2013-12-19
+        documentation_url: http://docs.jboss.org/tools/
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 417MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Update-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 93MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/jbosstools-Sources-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 77MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/hibernatetools-Update-4.2.0.Alpha1_2013-12-11_01-09-15-B32.zip.MD5
+          - name: Release Notes
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.2.0.x/zz_Release_Notes_4.2.0.Alpha1.readme.html
 
     kepler:
       4.1.2.Final:
-        archived: false
+        archived: true
         release_date: 2014-03-24
         supported_jbt_is_version: 4.1.7.Final
         documentation_url: http://docs.jboss.org/tools/4.1.x.Final/
@@ -1672,8 +1673,8 @@ jbt_core:
             file_size: 13kB
             url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.x/zz_Release_Notes_4.1.2.Final.readme.html
       4.1.2.CR1:
-        # archived: true
-        # renamed_as: 4.1.2.Final
+        archived: true
+        renamed_as: 4.1.2.Final
       4.1.1.Final:
         archived: true
         release_date: 2013-12-16
@@ -1698,84 +1699,84 @@ jbt_core:
             file_size: 7.5kB
             url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.x/zz_Release_Notes_4.1.1.Final.readme.html
       4.1.1.CR1:
-        # archived: true
-        # release_date: 2013-11-29
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 438.1MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.CR1_2013-11-24_01-06-56-B575.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.CR1_2013-11-24_01-06-56-B575.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 97.8MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.CR1_2013-11-24_01-06-56-B575.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.CR1_2013-11-24_01-06-56-B575.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 82.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.CR1_2013-11-24_01-06-56-B575.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.CR1_2013-11-24_01-06-56-B575.zip.MD5
-        #   - name: Release Notes
-        #     file_size: 27.1kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/zz_Release_Notes_4.1.1.CR1.readme.html
+        archived: true
+        release_date: 2013-11-29
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 438.1MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.CR1_2013-11-24_01-06-56-B575.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.CR1_2013-11-24_01-06-56-B575.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 97.8MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.CR1_2013-11-24_01-06-56-B575.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.CR1_2013-11-24_01-06-56-B575.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 82.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.CR1_2013-11-24_01-06-56-B575.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.CR1_2013-11-24_01-06-56-B575.zip.MD5
+          - name: Release Notes
+            file_size: 27.1kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/zz_Release_Notes_4.1.1.CR1.readme.html
 
       4.1.1.Beta1:
-        # archived: true
-        # release_date: 2013-11-08
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 423.9MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 86.7MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 82.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip.MD5
-        #   - name: Release Notes
-        #     file_size: 22.3kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/zz_Release_Notes_4.1.1.Beta1.readme.html
+        archived: true
+        release_date: 2013-11-08
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 423.9MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 86.7MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 82.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Beta1_2013-11-02_11-05-10-B511.zip.MD5
+          - name: Release Notes
+            file_size: 22.3kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/zz_Release_Notes_4.1.1.Beta1.readme.html
 
       4.1.1.Alpha2:
-        # archived: true
-        # release_date: 2013-10-14
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 432.5MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 91.2MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 82.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip.MD5
-        #   - name: Release Notes
-        #     file_size: 11.2kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/zz_Release_Notes_4.1.1.Alpha2.readme.html
+        archived: true
+        release_date: 2013-10-14
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 432.5MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 91.2MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 82.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Alpha2_2013-10-02_14-08-05-B444.zip.MD5
+          - name: Release Notes
+            file_size: 11.2kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/zz_Release_Notes_4.1.1.Alpha2.readme.html
 
       4.1.1.Alpha1:
-        # archived: true
-        # release_date: 2013-09-12
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 432.2MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 92.3MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 82.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip.MD5
-        #   - name: Release Notes
-        #     file_size: 16.5kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/zz_Release_Notes_4.1.1.Alpha1.readme.html
+        archived: true
+        release_date: 2013-09-12
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 432.2MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Update-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 92.3MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/jbosstools-Sources-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 82.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/hibernatetools-Update-4.1.1.Alpha1_2013-09-08_21-08-29-B392.zip.MD5
+          - name: Release Notes
+            file_size: 16.5kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.1.x/zz_Release_Notes_4.1.1.Alpha1.readme.html
 
       4.1.0.Final:
         archived: true
@@ -1808,84 +1809,84 @@ jbt_core:
             url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.x/zz_Release_Notes_4.1.0.Final.readme.html
 
       4.1.0.CR1:
-        # archived: true
-        # renamed_as: 4.1.0.Final
+        archived: true
+        renamed_as: 4.1.0.Final
 
       4.1.0.Beta2:
-        # archived: true
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 419.4MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 139.7MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 82.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip.MD5
-        #   - name: Release Notes
-        #     file_size: 44.6kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/zz_Release_Notes_4.1.0.Beta2.readme.html
+        archived: true
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 419.4MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 139.7MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 82.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Beta2_2013-06-25_22-05-55-B368.zip.MD5
+          - name: Release Notes
+            file_size: 44.6kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/zz_Release_Notes_4.1.0.Beta2.readme.html
 
       4.1.0.Beta1:
-        # archived: true
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 422.5MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 139.2MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 82.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip.MD5
-        #   - name: Release Notes
-        #     file_size: 53.7kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/zz_Release_Notes_4.1.0.Beta1.readme.html
+        archived: true
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 422.5MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 139.2MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 82.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Beta1_2013-05-29_02-05-21-B272.zip.MD5
+          - name: Release Notes
+            file_size: 53.7kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/zz_Release_Notes_4.1.0.Beta1.readme.html
 
       4.1.0.Alpha2:
-        # archived: true
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 315.7MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 103.3MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 82.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip.MD5
-        #   - name: Release Notes
-        #     file_size: 43.6kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/zz_Release_Notes_4.1.0.Alpha2.readme.html
+        archived: true
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 315.7MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 103.3MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 82.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Alpha2_2013-04-24_17-20-04-B202.zip.MD5
+          - name: Release Notes
+            file_size: 43.6kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/zz_Release_Notes_4.1.0.Alpha2.readme.html
 
       4.1.0.Alpha1:
-        # archived: true
-        # zips:
-        #   - name: Update site (including sources) bundle of all JBoss Core Tools
-        #     file_size: 199.8MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip.MD5
-        #   - name: Sources zip of all JBoss Core Tools
-        #     file_size: 101.9MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip.MD5
-        #   - name: Update site (including sources) bundle of all Hibernate Tools
-        #     file_size: 82.0MB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip
-        #     md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip.MD5
-        #   - name: Release Notes
-        #     file_size: 31.8kB
-        #     url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/zz_Release_Notes_4.1.0.Alpha1.readme.html
+        archived: true
+        zips:
+          - name: Update site (including sources) bundle of all JBoss Core Tools
+            file_size: 199.8MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Update-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip.MD5
+          - name: Sources zip of all JBoss Core Tools
+            file_size: 101.9MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/jbosstools-Sources-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip.MD5
+          - name: Update site (including sources) bundle of all Hibernate Tools
+            file_size: 82.0MB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip
+            md5_url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/hibernatetools-Update-4.1.0.Alpha1_2013-03-05_18-16-27-B134.zip.MD5
+          - name: Release Notes
+            file_size: 31.8kB
+            url: http://sourceforge.net/projects/jboss/files/JBossTools/JBossTools4.1.0.x/zz_Release_Notes_4.1.0.Alpha1.readme.html
 
     juno:
       4.0.1.Final:
@@ -2047,16 +2048,16 @@ jbt_is:
              file_size: 56MB
              url: http://download.jboss.org/jbosstools/neon/stable/updates/integration-stack/jbosstools-integration-stack-4.4.0.Final-updatesite-earlyaccess.zip
              md5_url: http://download.jboss.org/jbosstools/neon/stable/updates/integration-stack/jbosstools-integration-stack-4.4.0.Final-updatesite-earlyaccess.zip.MD5
-      # 4.4.0.Alpha1:
-      #   documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/
-      #   release_date: 2016-09-27
-      #   required_jbt_core_version: 4.4.1.Final
-      #   update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/earlyaccess
-      #   zips:
-      #     - name: Update site bundle of JBoss Tools Integration Stack (Early Access)
-      #       file_size: 211MB
-      #       url: http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/jbosstools-integration-stack-4.4.0.Alpha1-earlyaccess.zip
-      #       md5_url: http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/jbosstools-integration-stack-4.4.0.Alpha1-earlyaccess.zip.MD5
+      4.4.0.Alpha1:
+        documentation_url: https://access.redhat.com/site/documentation/en-US/Red_Hat_JBoss_Developer_Studio_Integration_Stack/
+        release_date: 2016-09-27
+        required_jbt_core_version: 4.4.1.Final
+        update_site_url: http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/earlyaccess
+        zips:
+          - name: Update site bundle of JBoss Tools Integration Stack (Early Access)
+            file_size: 211MB
+            url: http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/jbosstools-integration-stack-4.4.0.Alpha1-earlyaccess.zip
+            md5_url: http://download.jboss.org/jbosstools/neon/development/updates/integration-stack/jbosstools-integration-stack-4.4.0.Alpha1-earlyaccess.zip.MD5
     mars:
       4.3.3.Final:
         release_date: 2016-11-09
@@ -2106,28 +2107,28 @@ jbt_is:
             url: http://download.jboss.org/jbosstools/mars/stable/updates/integration-stack/jbosstools-integration-stack-4.3.0.Final-earlyaccess.zip
             md5_url: http://download.jboss.org/jbosstools/mars/stable/updates/integration-stack/jbosstools-integration-stack-4.3.0.Final-earlyaccess.zip.MD5
       4.3.0.Beta1:
-        # release_date: 2016-03-10
-        # required_jbt_core_version: 4.3.1.Beta2
-        # update_site_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/earlyaccess
-        # blog_announcement_url: /blog/integration-stack-4.3.0.Beta1-for-mars.html
-        # zips:
-        #   - name: Update site bundle of JBoss Tools Integration Stack (Early Access)
-        #     file_size: 193MB
-        #     url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Beta1-earlyaccess.zip
-        #     md5_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Beta1-earlyaccess.zip.MD5
+        release_date: 2016-03-10
+        required_jbt_core_version: 4.3.1.Beta2
+        update_site_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/earlyaccess
+        blog_announcement_url: /blog/integration-stack-4.3.0.Beta1-for-mars.html
+        zips:
+          - name: Update site bundle of JBoss Tools Integration Stack (Early Access)
+            file_size: 193MB
+            url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Beta1-earlyaccess.zip
+            md5_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Beta1-earlyaccess.zip.MD5
       4.3.0.Alpha2:
-        # release_date: 2015-10-12
-        # required_jbt_core_version: 4.3.0.Final
-        # update_site_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/
-        # zips:
-        #   - name: Update site bundle of JBoss Tools Integration Stack
-        #     file_size: 29MB
-        #     url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Alpha2.zip
-        #     md5_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Alpha2.zip.MD5
-        #   - name: Update site bundle of JBoss Tools Integration Stack (Early Access)
-        #     file_size: 208MB
-        #     url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Alpha2-earlyaccess.zip
-        #     md5_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Alpha2-earlyaccess.zip.MD5
+        release_date: 2015-10-12
+        required_jbt_core_version: 4.3.0.Final
+        update_site_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/
+        zips:
+          - name: Update site bundle of JBoss Tools Integration Stack
+            file_size: 29MB
+            url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Alpha2.zip
+            md5_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Alpha2.zip.MD5
+          - name: Update site bundle of JBoss Tools Integration Stack (Early Access)
+            file_size: 208MB
+            url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Alpha2-earlyaccess.zip
+            md5_url: http://download.jboss.org/jbosstools/mars/development/updates/integration-stack/jbosstools-integration-stack-4.3.0.Alpha2-earlyaccess.zip.MD5
     luna:
       4.2.7.Final:
         release_date: 2016-06-02
@@ -2217,27 +2218,27 @@ jbt_is:
             url: http://download.jboss.org/jbosstools/updates/stable/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Final.zip
             md5_url: http://download.jboss.org/jbosstools/updates/stable/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Final.zip.MD5
       4.2.0.Beta2:
-        # blog_announcement_url: /blog/2015-01-13-JBTIS-Beta2-for-luna.html
-        # #release_notes_url: https://devstudio.jboss.com/updates/8.0/integration-stack/release-notes/Release_Notes_8.0.0.html
-        # release_date: 2015-01-12
-        # required_jbt_core_version: 4.2.1.Final
-        # update_site_url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/
-        # zips:
-        #   - name: Update site bundle of JBoss Tools Integration Stack
-        #     file_size: 214MB
-        #     url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Beta2a.zip
-        #     md5_url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Beta2a.zip.MD5
+        blog_announcement_url: /blog/2015-01-13-JBTIS-Beta2-for-luna.html
+        #release_notes_url: https://devstudio.jboss.com/updates/8.0/integration-stack/release-notes/Release_Notes_8.0.0.html
+        release_date: 2015-01-12
+        required_jbt_core_version: 4.2.1.Final
+        update_site_url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/
+        zips:
+          - name: Update site bundle of JBoss Tools Integration Stack
+            file_size: 214MB
+            url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Beta2a.zip
+            md5_url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Beta2a.zip.MD5
       4.2.0.Beta1:
-        # blog_announcement_url: /blog/2014-11-13-JBTIS-Beta1-for-luna.html
-        # #release_notes_url: https://devstudio.jboss.com/updates/8.0/integration-stack/release-notes/Release_Notes_8.0.0.html
-        # release_date: 2014-11-12
-        # required_jbt_core_version: 4.2.0.Final
-        # update_site_url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/
-        # zips:
-        #   - name: Update site bundle of JBoss Tools Integration Stack
-        #     file_size: 180MB
-        #     url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Beta1.zip
-        #     md5_url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Beta1.zip.MD5
+        blog_announcement_url: /blog/2014-11-13-JBTIS-Beta1-for-luna.html
+        #release_notes_url: https://devstudio.jboss.com/updates/8.0/integration-stack/release-notes/Release_Notes_8.0.0.html
+        release_date: 2014-11-12
+        required_jbt_core_version: 4.2.0.Final
+        update_site_url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/
+        zips:
+          - name: Update site bundle of JBoss Tools Integration Stack
+            file_size: 180MB
+            url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Beta1.zip
+            md5_url: http://download.jboss.org/jbosstools/updates/development/luna/integration-stack/aggregate/jbosstools-integration-stack-aggregate-4.2.0.Beta1.zip.MD5
     kepler:
       4.1.7.Final:
         build_type: stable


### PR DESCRIPTION
…s New pages

Reverted the products that were commented out: as there are some N&N for
these versions, the site generator extensions assume that the product
is going to be released soon, hence they all appear in a "coming soon"
state.
The current solution is to mark them all as "archived: true" to remove
them from the main pages. They still appear in the /downloads/overview
page, though.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>