### PR TITLE
Minor corrections to devstudio 12 blog

### DIFF
--- a/blog/12.0.0.ga-for-photon.adoc
+++ b/blog/12.0.0.ga-for-photon.adoc
@@ -10,9 +10,9 @@ image::/blog/images/devstudio12.png[]
 
 == Installation
 
-JBoss Developer Studio comes with everything pre-bundled in its installer. Simply download it from our https://www.jboss.org/products/devstudio.html[JBoss Products page] and run it like this:
+Red Hat Developer Studio comes with everything pre-bundled in its installer. Simply download it from our https://developers.redhat.com/products/devstudio/overview/[Red Hat Developer product page] and run it like this:
 
-    java -jar jboss-devstudio-<installername>.jar
+    java -jar devstudio-<installername>.jar
 
 JBoss Tools or Bring-Your-Own-Eclipse (BYOE) Developer Studio require a bit more:
 
@@ -51,24 +51,24 @@ A server adapter has been added to work with Wildfly 13. It adds support for Ser
 
 ==== Camel Rest DSL from WSDL wizard
 
-There is a new _"Camel Rest DSL from WSDL"_ wizard. This wizard wraps the link:https://github.com/jboss-fuse/wsdl2rest[wsdl2rest tool] now included with the Fuse 7 distribution, which 
-takes a WSDL file for a SOAP-based (JAX-WS) web service and generates a combination of CXF-generated code and a Camel REST DSL route to make it accessible using REST operations. 
+There is a new _"Camel Rest DSL from WSDL"_ wizard. This wizard wraps the link:https://github.com/jboss-fuse/wsdl2rest[wsdl2rest tool] now included with the Fuse 7 distribution, which
+takes a WSDL file for a SOAP-based (JAX-WS) web service and generates a combination of CXF-generated code and a Camel REST DSL route to make it accessible using REST operations.
 
-To start, you need an existing Fuse Integration project in your workspace and access to the WSDL for the SOAP service. Then use 
-_File->New->Other..._ and select _Red Hat Fuse->Camel Rest DSL from WSDL_ wizard. 
+To start, you need an existing Fuse Integration project in your workspace and access to the WSDL for the SOAP service. Then use
+_File->New->Other..._ and select _Red Hat Fuse->Camel Rest DSL from WSDL_ wizard.
 
-On the first page of the wizard, select your WSDL and the Fuse Integration project in which to generate the Java code and Camel configuration. 
+On the first page of the wizard, select your WSDL and the Fuse Integration project in which to generate the Java code and Camel configuration.
 
 image::/documentation/whatsnew/fusetools/images/wsdl2rest-wizard-page-one.jpg[SOAP to REST Wizard page 1]
 
-On the second page, you can customize the Java folder path for your generated classes, the folder for the generated Camel file, plus any customization for the SOAP service 
-address and destination REST service address. 
+On the second page, you can customize the Java folder path for your generated classes, the folder for the generated Camel file, plus any customization for the SOAP service
+address and destination REST service address.
 
 image::/documentation/whatsnew/fusetools/images/wsdl2rest-wizard-page-two.jpg[SOAP to REST Wizard page 2]
 
-Click _Finish_ and the new Camel configuration and associated Java code are generated in your project. The wizard determines whether your project is Blueprint, 
-Spring, or Spring Boot based, and it creates the corresponding artifacts without requiring any additional input. When the wizard is finished, you can open your 
-new Camel file in the Fuse Tooling Route Editor to view what it created. 
+Click _Finish_ and the new Camel configuration and associated Java code are generated in your project. The wizard determines whether your project is Blueprint,
+Spring, or Spring Boot based, and it creates the corresponding artifacts without requiring any additional input. When the wizard is finished, you can open your
+new Camel file in the Fuse Tooling Route Editor to view what it created.
 
 image::/documentation/whatsnew/fusetools/images/fuse-editor-rest-tab-no-properties.jpg[Fuse Tooling editor Rest Tab]
 
@@ -88,7 +88,7 @@ image::/documentation/whatsnew/fusetools/images/fuse-editor-rest-tab-rest-elemen
 
 image::/documentation/whatsnew/fusetools/images/fuse-editor-rest-tab-rest-operation-properties.jpg[Fuse Tooling Rest Operations Properties View]
 
-For this release, the REST tab is read-only. If you want to edit the REST DSL, use the Route Editor Source tab. When you make changes and save them in the Source tab, the 
+For this release, the REST tab is read-only. If you want to edit the REST DSL, use the Route Editor Source tab. When you make changes and save them in the Source tab, the
 REST tab refreshes to show your updates.
 
 ==== Camel URI completion with XML DSL
@@ -311,7 +311,7 @@ Versions 2.2.0 and greater of bundle ```org.eclipse.jdt.annotation``` use the la
 ===== @NonNullByDefault improvements
 
 When using annotation-based null analysis, there are now more ways to define which unannotated locations are implicitly assumed to be annotated as ```@NonNull```:
- 
+
 - ```@NonNullByDefault``` annotations based on enum ```DefaultLocation``` can also be used if the primary nullness annotations are declaration annotations (previously this was supported only for ```TYPE_USE``` annotations).
 - Support for ```@NonNullByDefault``` annotations that are targeted at parameters has been implemented.
 - Multiple different ```@NonNullByDefault``` annotations (especially with different default values) may be placed at the same target, in which case the sets of affected locations are merged.


### PR DESCRIPTION
Remove JBoss from product name and also link to d.rh.c instead of old
jboss.org site which gets redirected to the new site anyway