### PR TITLE
JBDS-4730: Use "Red Hat CodeReady Studio" instead of "Red Hat Develop…

### DIFF
--- a/documentation/faq/index.adoc
+++ b/documentation/faq/index.adoc
@@ -15,7 +15,7 @@ Go to link:../../downloads[Downloads] to select the distribution that fits your 
 +
 Here you can:
 
-  * Choose an all-in-one install via link:https://www.jboss.org/products/devstudio[Red Hat Developer Studio], or
+  * Choose an all-in-one install via link:https://www.jboss.org/products/devstudio[Red Hat CodeReady Studio], or
   * Choose individual features from the link:/downloads/[JBoss Tools] update site, or
   * Install from the link:http://marketplace.eclipse.org/[Eclipse Marketplace].
 

--- a/documentation/howto/configure_remote_server.adoc
+++ b/documentation/howto/configure_remote_server.adoc
@@ -5,7 +5,7 @@
 
 :imagesdir: ./images
 
-Remote servers allow developers to access and deploy to a JBoss instance that is not a local machine. Developers can use remote servers to set up multiple environments for development and testing purposes and share them with other developers. Another reason to use a remote server with Red Hat Developer Studio is to allow developers to share and deploy automated tests to run in a non-local environment.
+Remote servers allow developers to access and deploy to a JBoss instance that is not a local machine. Developers can use remote servers to set up multiple environments for development and testing purposes and share them with other developers. Another reason to use a remote server with Red Hat CodeReady Studio is to allow developers to share and deploy automated tests to run in a non-local environment.
 
 The following instructions are used to set up a remote server for JBoss Enterprise Middleware application servers. A complete server definition requires a server adapter (or server) that allows the IDE to communicate with and manage the remote server.
 

--- a/documentation/howto/forge.adoc
+++ b/documentation/howto/forge.adoc
@@ -5,7 +5,7 @@
 :experimental:
 :imagesdir: ./images
 
-Red Hat Developer Studio offers Forge Tools for developing Java EE applications and to extend the IDE functionality in Eclipse. Start developing Java EE applications using either the Forge context menu or the command line from the IDE.
+Red Hat CodeReady Studio offers Forge Tools for developing Java EE applications and to extend the IDE functionality in Eclipse. Start developing Java EE applications using either the Forge context menu or the command line from the IDE.
 
 == Create a New Project
 

--- a/downloads/installation.adoc
+++ b/downloads/installation.adoc
@@ -9,7 +9,7 @@ All downloads can be found at link:../downloads/overview.html[Download overview]
 
 === Installer
 
-Red Hat Developer Studio includes the supported plugins from
+Red Hat CodeReady Studio includes the supported plugins from
 JBoss Tools, plus some additional tools, and comes bundled in an
 easy-to-use installer for Windows, Mac, and Linux (32- and 64-bit). It
 can be link:../downloads[downloaded] for free. Perfect for offline


### PR DESCRIPTION
…er Studio" in graphics & text

Signed-off-by: Jeff MAURY <jmaury@redhat.com>