### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d3c9825d67b0d8720afdfdde5af56c79fdb38d16 #v1
       with:
         ruby-version: 2.4.1
         bundler-cache: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@d3c9825d67b0d8720afdfdde5af56c79fdb38d16 #v1
       with:
         ruby-version: 2.4.1
         bundler-cache: true

--- a/.github/workflows/surge.yml
+++ b/.github/workflows/surge.yml
@@ -13,14 +13,14 @@ jobs:
         with:
           ref: ${{github.event.workflow_run.head_sha}}
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@d3c9825d67b0d8720afdfdde5af56c79fdb38d16 #v1
         with:
           ruby-version: 2.4.1
           bundler-cache: true
       - name: Generate site
         run: |
           bundle exec rake actions
-      - uses: afc163/surge-preview@v1
+      - uses: afc163/surge-preview@aef1ba438fafc353616c0bf225b6803bdd6367d2 #v1
         id: preview_step
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
